### PR TITLE
Add navigation control to map

### DIFF
--- a/ui/src/Pages/PlacesPage/PlacesPage.js
+++ b/ui/src/Pages/PlacesPage/PlacesPage.js
@@ -59,6 +59,9 @@ const MapPage = () => {
       zoom: 1,
     })
 
+    // Add map navigation control
+    map.current.addControl(new mapboxLibrary.NavigationControl())
+
     map.current.on('load', () => {
       map.current.addSource('media', {
         type: 'geojson',


### PR DESCRIPTION
In places tab, navigation controls are added to the mapbox map, see example.

![Navigation](https://user-images.githubusercontent.com/8471630/103382896-0d8f4900-4af1-11eb-9d77-dfe505a603a9.png)
