### PR TITLE
Prefixed the env variables to avoid naming collisions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Build UI
 FROM --platform=${BUILDPLATFORM:-linux/amd64} node:10 as ui
 
-ARG API_ENDPOINT
-ENV API_ENDPOINT=${API_ENDPOINT}
+ARG PHOTOVIEW_API_ENDPOINT
+ENV PHOTOVIEW_API_ENDPOINT=${PHOTOVIEW_API_ENDPOINT}
 
 # Set environment variable UI_PUBLIC_URL from build args, uses "/" as default
 ARG UI_PUBLIC_URL
@@ -49,10 +49,10 @@ RUN apk --no-cache add ffmpeg; exit 0
 COPY --from=ui /app/dist /ui
 COPY --from=api /app/photoview /app/photoview
 
-ENV API_LISTEN_IP 127.0.0.1
-ENV API_LISTEN_PORT 80
+ENV PHOTOVIEW_LISTEN_IP 127.0.0.1
+ENV PHOTOVIEW_LISTEN_PORT 80
 
-ENV SERVE_UI 1
+ENV PHOTOVIEW_SERVE_UI 1
 
 EXPOSE 80
 

--- a/api/example.env
+++ b/api/example.env
@@ -2,17 +2,17 @@
 
 MYSQL_URL=user:password@tcp(localhost)/dbname
 
-API_LISTEN_IP=localhost
-API_LISTEN_PORT=4001
+PHOTOVIEW_LISTEN_IP=localhost
+PHOTOVIEW_LISTEN_PORT=4001
 
 # The url from which the server can be accessed publicly
-API_ENDPOINT=http://localhost:4001/
-UI_ENDPOINT=http://localhost:1234/
+PHOTOVIEW_API_ENDPOINT=http://localhost:4001/
+PHOTOVIEW_UI_ENDPOINT=http://localhost:1234/
 
 # Set to 1 for the server to also serve the built static ui files
-SERVE_UI=0
-# When SERVE_UI is 1, PUBLIC_ENDPOINT is used instead of API_ENDPOINT and UI_ENDPOINT
-#PUBLIC_ENDPOINT=http://localhost:4001/
+PHOTOVIEW_SERVE_UI=0
+# When PHOTOVIEW_SERVE_UI is 1, PHOTOVIEW_PUBLIC_ENDPOINT is used instead of PHOTOVIEW_API_ENDPOINT and PHOTOVIEW_UI_ENDPOINT
+#PHOTOVIEW_PUBLIC_ENDPOINT=http://localhost:4001/
 
 # Enter a valid mapbox token, to enable maps feature
 # A token can be created for free at https://mapbox.com
@@ -20,4 +20,4 @@ SERVE_UI=0
 
 # Set to 1 to set server in development mode, this enables graphql playground
 # Remove this if running in production
-DEVELOPMENT=1
+PHOTOVIEW_DEVELOPMENT_MODE=1

--- a/api/server.go
+++ b/api/server.go
@@ -29,7 +29,7 @@ func main() {
 		log.Println("No .env file found")
 	}
 
-	devMode := os.Getenv("DEVELOPMENT") == "1"
+	devMode := os.Getenv("PHOTOVIEW_DEVELOPMENT_MODE") == "1"
 
 	db, err := database.SetupDatabase()
 	if err != nil {
@@ -92,7 +92,7 @@ func main() {
 	videoRouter := endpointRouter.PathPrefix("/video").Subrouter()
 	routes.RegisterVideoRoutes(db, videoRouter)
 
-	shouldServeUI := os.Getenv("SERVE_UI") == "1"
+	shouldServeUI := os.Getenv("PHOTOVIEW_SERVE_UI") == "1"
 
 	if shouldServeUI {
 		spa := routes.NewSpaHandler("/ui", "index.html")
@@ -111,7 +111,7 @@ func main() {
 		log.Printf("Photoview UI public endpoint ready at %s\n", uiEndpoint.String())
 
 		if !shouldServeUI {
-			log.Printf("Notice: UI is not served by the the api (SERVE_UI=0)")
+			log.Printf("Notice: UI is not served by the the api (PHOTOVIEW_SERVE_UI=0)")
 		}
 
 	}

--- a/api/server/websocket.go
+++ b/api/server/websocket.go
@@ -30,7 +30,7 @@ func WebsocketUpgrader(devMode bool) websocket.Upgrader {
 				if uiEndpoint.Host == originURL.Host {
 					return true
 				} else {
-					log.Printf("Not allowing websocket request from %s because it doesn't match UI_ENDPOINT %s", originURL.Host, uiEndpoint.Host)
+					log.Printf("Not allowing websocket request from %s because it doesn't match PHOTOVIEW_UI_ENDPOINT %s", originURL.Host, uiEndpoint.Host)
 					return false
 				}
 			}

--- a/api/utils/Endpoints.go
+++ b/api/utils/Endpoints.go
@@ -12,7 +12,7 @@ import (
 func ApiListenUrl() *url.URL {
 	const defaultPort = "4001"
 
-	shouldServeUI := os.Getenv("SERVE_UI") == "1"
+	shouldServeUI := os.Getenv("PHOTOVIEW_SERVE_UI") == "1"
 
 	apiPrefix := "/"
 	if shouldServeUI {
@@ -21,19 +21,19 @@ func ApiListenUrl() *url.URL {
 
 	var listenAddr string
 
-	listenAddr = os.Getenv("API_LISTEN_IP")
+	listenAddr = os.Getenv("PHOTOVIEW_LISTEN_IP")
 	if listenAddr == "" {
 		listenAddr = "127.0.0.1"
 	}
 
-	listenPortStr := os.Getenv("API_LISTEN_PORT")
+	listenPortStr := os.Getenv("PHOTOVIEW_LISTEN_PORT")
 	if listenPortStr == "" {
 		listenPortStr = defaultPort
 	}
 
 	listenPort, err := strconv.Atoi(listenPortStr)
 	if err != nil {
-		log.Fatalf("API_LISTEN_PORT must be a number: '%s'\n%s", listenPortStr, err)
+		log.Fatalf("PHOTOVIEW_LISTEN_PORT must be a number: '%s'\n%s", listenPortStr, err)
 	}
 
 	apiUrl, err := url.Parse(fmt.Sprintf("http://%s:%d", listenAddr, listenPort))
@@ -46,16 +46,16 @@ func ApiListenUrl() *url.URL {
 }
 
 func ApiEndpointUrl() *url.URL {
-	apiEndpointStr := os.Getenv("API_ENDPOINT")
+	apiEndpointStr := os.Getenv("PHOTOVIEW_API_ENDPOINT")
 
-	shouldServeUI := os.Getenv("SERVE_UI") == "1"
+	shouldServeUI := os.Getenv("PHOTOVIEW_SERVE_UI") == "1"
 	if shouldServeUI {
-		apiEndpointStr = os.Getenv("PUBLIC_ENDPOINT")
+		apiEndpointStr = os.Getenv("PHOTOVIEW_PUBLIC_ENDPOINT")
 	}
 
 	apiEndpointUrl, err := url.Parse(apiEndpointStr)
 	if err != nil {
-		log.Fatalf("ERROR: Environment variable API_ENDPOINT is not a proper url")
+		log.Fatalf("ERROR: Environment variable PHOTOVIEW_API_ENDPOINT is not a proper url")
 	}
 
 	if shouldServeUI {
@@ -66,16 +66,16 @@ func ApiEndpointUrl() *url.URL {
 }
 
 func UiEndpointUrl() *url.URL {
-	uiEndpointStr := os.Getenv("UI_ENDPOINT")
+	uiEndpointStr := os.Getenv("PHOTOVIEW_UI_ENDPOINT")
 
-	shouldServeUI := os.Getenv("SERVE_UI") == "1"
+	shouldServeUI := os.Getenv("PHOTOVIEW_SERVE_UI") == "1"
 	if shouldServeUI {
-		uiEndpointStr = os.Getenv("PUBLIC_ENDPOINT")
+		uiEndpointStr = os.Getenv("PHOTOVIEW_PUBLIC_ENDPOINT")
 	}
 
 	uiEndpointUrl, err := url.Parse(uiEndpointStr)
 	if err != nil {
-		log.Fatalf("ERROR: Environment variable UI_ENDPOINT is not a proper url")
+		log.Fatalf("ERROR: Environment variable PHOTOVIEW_UI_ENDPOINT is not a proper url")
 	}
 
 	return uiEndpointUrl

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -22,14 +22,14 @@ services:
 
     environment:
       - MYSQL_URL=photoview:photo-secret@tcp(db)/photoview
-      - API_LISTEN_IP=photoview
-      - API_LISTEN_PORT=80
+      - PHOTOVIEW_LISTEN_IP=photoview
+      - PHOTOVIEW_LISTEN_PORT=80
       - PHOTO_CACHE=/app/cache
 
       # Change This: The publicly exposed url
       # For example if the server is available from the domain example.com,
       # change this value to http://example.com/
-      - PUBLIC_ENDPOINT=http://localhost:8000/
+      - PHOTOVIEW_PUBLIC_ENDPOINT=http://localhost:8000/
 
       # Optional: To enable map related features, you need to create a mapbox token.
       # A token can be generated for free here https://account.mapbox.com/access-tokens/

--- a/ui/example.env
+++ b/ui/example.env
@@ -1,1 +1,1 @@
-API_ENDPOINT=http://localhost:4001/
+PHOTOVIEW_API_ENDPOINT=http://localhost:4001/

--- a/ui/src/apolloClient.js
+++ b/ui/src/apolloClient.js
@@ -13,8 +13,8 @@ import urlJoin from 'url-join'
 import { clearTokenCookie } from './authentication'
 import { MessageState } from './components/messages/Messages'
 
-export const GRAPHQL_ENDPOINT = process.env.API_ENDPOINT
-  ? urlJoin(process.env.API_ENDPOINT, '/graphql')
+export const GRAPHQL_ENDPOINT = process.env.PHOTOVIEW_API_ENDPOINT
+  ? urlJoin(process.env.PHOTOVIEW_API_ENDPOINT, '/graphql')
   : urlJoin(location.origin, '/api/graphql')
 
 const httpLink = new HttpLink({


### PR DESCRIPTION
Prefixed the env variables to avoid naming collisions