### PR TITLE
V2 Ignore Directories

### DIFF
--- a/api/scanner/scanner_user.go
+++ b/api/scanner/scanner_user.go
@@ -101,7 +101,7 @@ func findAlbumsForUser(db *gorm.DB, user *models.User, album_cache *AlbumScanner
 
 		// Skip this dir if in ignore list
 		ignorePaths := ignore.CompileIgnoreLines(albumIgnore...)
-		if (ignorePaths.MatchesPath(albumPath)) {
+		if (ignorePaths.MatchesPath(albumPath + "/")) {
 			log.Printf("Skip, directroy %s is in ignore file", albumPath)
 			continue
 		}


### PR DESCRIPTION
Looks for .photoviewignore file in all root dirs and potential subdirs.
Subdirs inherit the ignore rules from parent dir. If a .photoviewignore
file is found in a subdir, the new ignore rules are appended to the
existing ignore rules.

Ignore match engine is from 'github.com/sabhiram/go-gitignore'.

Signed-off-by: Kjeldgaard <Kjeldgaard@users.noreply.github.com>