### PR TITLE
Ignore media files

### DIFF
--- a/api/graphql/models/album.go
+++ b/api/graphql/models/album.go
@@ -17,7 +17,6 @@ type Album struct {
 	Owners   []User `gorm:"many2many:user_albums"`
 	Path     string `gorm:"not null"`
 	PathHash string `gorm:"unique"`
-	IgnoreFiles string
 }
 
 func (a *Album) FilePath() string {

--- a/api/graphql/models/album.go
+++ b/api/graphql/models/album.go
@@ -17,6 +17,7 @@ type Album struct {
 	Owners   []User `gorm:"many2many:user_albums"`
 	Path     string `gorm:"not null"`
 	PathHash string `gorm:"unique"`
+	IgnoreFiles string
 }
 
 func (a *Album) FilePath() string {

--- a/api/scanner/cache.go
+++ b/api/scanner/cache.go
@@ -10,6 +10,7 @@ import (
 type AlbumScannerCache struct {
 	path_contains_photos map[string]bool
 	photo_types          map[string]MediaType
+	ignore_data          map[string][]string
 	mutex                sync.Mutex
 }
 
@@ -17,6 +18,7 @@ func MakeAlbumCache() *AlbumScannerCache {
 	return &AlbumScannerCache{
 		path_contains_photos: make(map[string]bool),
 		photo_types:          make(map[string]MediaType),
+		ignore_data:          make(map[string][]string),
 	}
 }
 
@@ -83,4 +85,23 @@ func (c *AlbumScannerCache) GetMediaType(path string) (*MediaType, error) {
 	}
 
 	return mediaType, nil
+}
+
+func (c *AlbumScannerCache) GetAlbumIgnore(path string) (*[]string) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	ignore_data, found := c.ignore_data[path]
+	if found {
+		return &ignore_data
+	}
+
+	return nil
+}
+
+func (c *AlbumScannerCache) InsertAlbumIgnore(path string, ignore_data []string) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	c.ignore_data[path] = ignore_data
 }


### PR DESCRIPTION
Added feature to ignore specific media files. E.g. to ignore .png media
files, add '*.png' to .photoviewignore file or add 'img_1234.jpg' to
ignore a specific file. This applies to the current dir and any
potential subdir. Matching is case sensitive. File ignore pattern must
include a '.', otherwise the pattern is treated as a dir ignore pattern.

Signed-off-by: Kjeldgaard <Kjeldgaard@users.noreply.github.com>