### PR TITLE
update Kagami/go-face target commit and new deps for it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,7 @@ jobs:
           sudo add-apt-repository ppa:strukturag/libheif
           sudo add-apt-repository ppa:strukturag/libde265
           sudo apt-get update
-          sudo apt-get install -y libdlib-dev libblas-dev liblapack-dev libjpeg-turbo8-dev libheif-dev
+          sudo apt-get install -y libdlib-dev libblas-dev libatlas-base-dev liblapack-dev libjpeg-turbo8-dev libheif-dev
 
       - name: Get GO dependencies
         run: |

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ They can be installed as shown below:
 
 ```sh
 # Ubuntu
-sudo apt-get install libdlib-dev libblas-dev liblapack-dev libjpeg-turbo8-dev libheif-dev
+sudo apt-get install libdlib-dev libblas-dev libatlas-base-dev liblapack-dev libjpeg-turbo8-dev libheif-dev
 # Debian
-sudo apt-get install libdlib-dev libblas-dev liblapack-dev libjpeg62-turbo-dev libheif-dev
+sudo apt-get install libdlib-dev libblas-dev libatlas-base-dev liblapack-dev libjpeg62-turbo-dev libheif-dev
 # macOS
 brew install dlib libheif
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/99designs/gqlgen v0.13.0
-	github.com/Kagami/go-face v0.0.0-20200825065730-3dd2d74dccfb
+	github.com/Kagami/go-face v0.0.0-20210604182630-c482b0e1acfb
 	github.com/agnivade/levenshtein v1.1.0 // indirect
 	github.com/barasher/go-exiftool v1.4.0
 	github.com/disintegration/imaging v1.6.2

--- a/api/go.sum
+++ b/api/go.sum
@@ -5,8 +5,8 @@ github.com/99designs/gqlgen v0.13.0 h1:haLTcUp3Vwp80xMVEg5KRNwzfUrgFdRmtBY8fuB8s
 github.com/99designs/gqlgen v0.13.0/go.mod h1:NV130r6f4tpRWuAI+zsrSdooO/eWUv+Gyyoi3rEfXIk=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Kagami/go-face v0.0.0-20200825065730-3dd2d74dccfb h1:DXwA1Te9paM+nsdTGc7uve37lq7WEbQO+gwGBPVwQuQ=
-github.com/Kagami/go-face v0.0.0-20200825065730-3dd2d74dccfb/go.mod h1:9wdDJkRgo3SGTcFwbQ7elVIQhIr2bbBjecuY7VoqmPU=
+github.com/Kagami/go-face v0.0.0-20210604182630-c482b0e1acfb h1:/XDrbCx+BZHdUz8cudJBGdCVqMI+b4HMdH5Y8D7k7sA=
+github.com/Kagami/go-face v0.0.0-20210604182630-c482b0e1acfb/go.mod h1:9wdDJkRgo3SGTcFwbQ7elVIQhIr2bbBjecuY7VoqmPU=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible h1:1G1pk05UrOh0NlF1oeaaix1x8XzrfjIDK47TY0Zehcw=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=

--- a/docker/install_build_dependencies.sh
+++ b/docker/install_build_dependencies.sh
@@ -31,6 +31,7 @@ apt-get install -y ca-certificates golang
 apt-get install -y \
   libdlib-dev:${DEBIAN_ARCH} \
   libblas-dev:${DEBIAN_ARCH} \
+  libatlas-base-dev:${DEBIAN_ARCH} \
   liblapack-dev:${DEBIAN_ARCH} \
   libjpeg-dev:${DEBIAN_ARCH} \
   libheif-dev:${DEBIAN_ARCH}


### PR DESCRIPTION
go-face only linked blas, which caused issues on systems that don't bundle cblas with blas in the distribution repositories (e.g. Arch Linux). It was updated to explicitly link cblas. This requires Ubuntu systems (and similar distributions) to explicitly install cblas so the new linking doesn't fail. `libatlas-base-dev` is one way to solve this (and I tested it). OpenBLAS may also satisfy it, but I have not tested that.

Referencing the newer go-face commit allows systems such as Arch Linux to install photoview.