### PR TITLE
Treat symlinks to directories like directories

### DIFF
--- a/api/scanner/scanner_album.go
+++ b/api/scanner/scanner_album.go
@@ -181,7 +181,13 @@ func findMediaForAlbum(album *models.Album, cache *scanner_cache.AlbumScannerCac
 	for _, item := range dirContent {
 		photoPath := path.Join(album.Path, item.Name())
 
-		if !item.IsDir() && cache.IsPathMedia(photoPath) {
+		isDirSymlink, err := utils.IsDirSymlink(photoPath)
+		if err != nil {
+			log.Printf("Cannot detect whether %s is symlink to a directory. Pretending it is not", photoPath)
+			isDirSymlink = false
+		}
+
+		if !item.IsDir() && !isDirSymlink && cache.IsPathMedia(photoPath) {
 			// Match file against ignore data
 			if albumIgnore.MatchesPath(item.Name()) {
 				log.Printf("File %s ignored\n", item.Name())

--- a/api/utils/utils_test.go
+++ b/api/utils/utils_test.go
@@ -1,0 +1,77 @@
+package utils_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/photoview/photoview/api/test_utils"
+	"github.com/photoview/photoview/api/utils"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(test_utils.IntegrationTestRun(m))
+}
+
+func TestIsDirSymlink(t *testing.T) {
+	test_utils.FilesystemTest(t)
+
+	// Prepare a temporary directory for testing purposes
+	dir, err := ioutil.TempDir("", "testing")
+	if err != nil {
+		t.Fatalf("unable to create temp directory for testing")
+	}
+	defer os.RemoveAll(dir)
+
+	// Create regular file
+	_, err = os.Create(path.Join(dir, "regular_file"))
+	if err != nil {
+		t.Fatalf("unable to create regular file for testing")
+	}
+
+	// Create directory
+	err = os.Mkdir(path.Join(dir, "directory"), 0755)
+	if err != nil {
+		t.Fatalf("unable to create directory for testing")
+	}
+
+	// Create symlink to regular file
+	err = os.Symlink(path.Join(dir, "regular_file"), path.Join(dir, "file_link"))
+	if err != nil {
+		t.Fatalf("unable to create file link for testing")
+	}
+
+	// Create symlink to directory
+	err = os.Symlink(path.Join(dir, "directory"), path.Join(dir, "dir_link"))
+	if err != nil {
+		t.Fatalf("unable to create dir link for testing")
+	}
+
+	// Execute the actual tests
+
+	isDirLink, _ := utils.IsDirSymlink(path.Join(dir, "regular_file"))
+	if isDirLink {
+		t.Error("Failed detection of regular file")
+	}
+
+	isDirLink, _ = utils.IsDirSymlink(path.Join(dir, "directory"))
+	if isDirLink {
+		t.Error("Failed detection of directory")
+	}
+
+	isDirLink, _ = utils.IsDirSymlink(path.Join(dir, "file_link"))
+	if isDirLink {
+		t.Error("Failed detection of link to regular file")
+	}
+
+	isDirLink, _ = utils.IsDirSymlink(path.Join(dir, "dir_link"))
+	if !isDirLink {
+		t.Error("Failed detection of link to directory")
+	}
+
+	isDirLink, err = utils.IsDirSymlink(path.Join(dir, "non_existant"))
+	if err == nil {
+		t.Error("Missing error for non-existant file")
+	}
+}


### PR DESCRIPTION
This allows symlinking to create additional subalbums.

Closes: #431

One drawback is that the files in the symlinked directories are scanned twice as they have different paths. 
It would be nice if the applications identifies them as identical (e.g. based on an md5sum) and use the already scanned information for both subalbums (the real one and the symlink). But this is not part of this PR.