### PR TITLE
Patch fix for face images

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -21,3 +21,9 @@ html {
     transform: scale(1, -1);
   }
 }
+
+@layer base {
+  img {
+    max-width: revert;
+  }
+}


### PR DESCRIPTION
Patches up the x offset for face circle images on the people page, where the Tailwind base style overrides the existing layout. 

Should fix #438.

Reverting max-width should have no effect on other pages (and doesn't from my testing), since the width is explicitly defined in other cases.