### PR TITLE
Fix: Correctly display counterpart JPGs for RAWs

### DIFF
--- a/api/scanner/process_photo.go
+++ b/api/scanner/process_photo.go
@@ -121,6 +121,18 @@ func processPhoto(tx *gorm.DB, imageData *media_encoding.EncodeMediaData, photoC
 		return false, errors.Wrap(err, "could determine if media was photo or video")
 	}
 
+	if mediaType.IsRaw() {
+		err = processRawSideCar(tx, imageData, highResURL, thumbURL, photoCachePath)
+		if err != nil {
+			return false, err
+		}
+
+		counterpartFile := scanForCompressedCounterpartFile(photo.Path)
+		if counterpartFile != nil {
+			imageData.Media.CounterpartPath = counterpartFile
+		}
+	}
+
 	// Generate high res jpeg
 	if highResURL == nil {
 
@@ -199,18 +211,6 @@ func processPhoto(tx *gorm.DB, imageData *media_encoding.EncodeMediaData, photoC
 			if err != nil {
 				return false, errors.Wrap(err, "could not create thumbnail cached image")
 			}
-		}
-	}
-
-	if mediaType.IsRaw() {
-		err = processRawSideCar(tx, imageData, highResURL, thumbURL, photoCachePath)
-		if err != nil {
-			return false, err
-		}
-
-		counterpartFile := scanForCompressedCounterpartFile(photo.Path)
-		if counterpartFile != nil {
-			photo.CounterpartPath = counterpartFile
 		}
 	}
 

--- a/api/scanner/process_photo.go
+++ b/api/scanner/process_photo.go
@@ -148,12 +148,10 @@ func processPhoto(tx *gorm.DB, imageData *media_encoding.EncodeMediaData, photoC
 
 			baseImagePath = path.Join(*photoCachePath, highresName)
 
-			newHighResURL, err := generateSaveHighResJPEG(tx, photo, imageData, highresName, baseImagePath, nil)
+			_, err := generateSaveHighResJPEG(tx, photo, imageData, highresName, baseImagePath, nil)
 			if err != nil {
 				return false, err
 			}
-
-			highResURL = newHighResURL
 		}
 	} else {
 		// Verify that highres photo still exists in cache
@@ -193,12 +191,11 @@ func processPhoto(tx *gorm.DB, imageData *media_encoding.EncodeMediaData, photoC
 
 		thumbnailName := generateUniqueMediaNamePrefixed("thumbnail", photo.Path, ".jpg")
 
-		newThumbURL, err := generateSaveThumbnailJPEG(tx, photo, thumbnailName, photoCachePath, baseImagePath, nil)
+		_, err := generateSaveThumbnailJPEG(tx, photo, thumbnailName, photoCachePath, baseImagePath, nil)
 		if err != nil {
 			return false, err
 		}
 
-		thumbURL = newThumbURL
 	} else {
 		// Verify that thumbnail photo still exists in cache
 		thumbPath := path.Join(*photoCachePath, thumbURL.MediaName)


### PR DESCRIPTION
high res thumbnails were generated before counterparts for raw files were searched for. 

This fixes https://github.com/photoview/photoview/issues/418
