### PR TITLE
Fix bug in new install.

### DIFF
--- a/ui/src/components/timelineGallery/TimelineFilters.tsx
+++ b/ui/src/components/timelineGallery/TimelineFilters.tsx
@@ -38,23 +38,25 @@ const DateSelector = ({ filterDate, setFilterDate }: DateSelectorProps) => {
   ]
 
   if (data) {
-    const dateStr = data.myMedia[0].date
-    const date = new Date(dateStr)
-    const now = new Date()
+    if (data.myMedia.length != 0) {
+      const dateStr = data.myMedia[0].date
+      const date = new Date(dateStr)
+      const now = new Date()
 
-    const currentYear = now.getFullYear()
-    const earliestYear = date.getFullYear()
+      const currentYear = now.getFullYear()
+      const earliestYear = date.getFullYear()
 
-    const years: number[] = []
-    for (let i = currentYear - 1; i >= earliestYear; i--) {
-      years.push(i)
+      const years: number[] = []
+      for (let i = currentYear - 1; i >= earliestYear; i--) {
+        years.push(i)
+      }
+
+      const yearItems = years.map<DropdownItem>(x => ({
+        value: `${x}`,
+        label: `${x} and earlier`,
+      }))
+      items = [...items, ...yearItems]
     }
-
-    const yearItems = years.map<DropdownItem>(x => ({
-      value: `${x}`,
-      label: `${x} and earlier`,
-    }))
-    items = [...items, ...yearItems]
   }
 
   return (


### PR DESCRIPTION
In a new setup with no photos in the database, the default timeline will throw a TypeError - `TimelineFilters.tsx` doesn't check if the `myMedia` array is empty (but it does still need the null check, otherwise that object will be undefined).

(Only one line added, I didn't think it was worth opening a new issue!)