### PR TITLE
Fix slow query in getting media of a face by using another join

### DIFF
--- a/api/graphql/resolvers/faces.go
+++ b/api/graphql/resolvers/faces.go
@@ -145,8 +145,9 @@ func (r *queryResolver) FaceGroup(ctx context.Context, id int) (*models.FaceGrou
 
 	faceGroupQuery := db.
 		Joins("LEFT JOIN image_faces ON image_faces.face_group_id = face_groups.id").
+		Joins("LEFT JOIN media ON image_faces.media_id = media.id").
 		Where("face_groups.id = ?", id).
-		Where("image_faces.media_id IN (?)", db.Select("media_id").Table("media").Where("media.album_id IN (?)", userAlbumIDs))
+		Where("media.album_id IN (?)", userAlbumIDs)
 
 	var faceGroup models.FaceGroup
 	if err := faceGroupQuery.Find(&faceGroup).Error; err != nil {


### PR DESCRIPTION
The subquery returns all potential media id's. Typically, we have a couple of faces and thousands of media files. 
A join is much faster. 

With about 50k images and a face that was present in 2'000 images the query was unusable slow, it took about 60s. 
This is a very important performance fix, as I think many users will run into it. 
Maybe there are other areas where the same improvement is possible, I didn't check.