### PR TITLE
systemd run with opt deps

### DIFF
--- a/api/example.env
+++ b/api/example.env
@@ -30,3 +30,6 @@ PHOTOVIEW_SERVE_UI=0
 # Set to 1 to set server in development mode, this enables graphql playground
 # Remove this if running in production
 PHOTOVIEW_DEVELOPMENT_MODE=1
+
+# For the systemd-unit to be able to find optional dependencies
+PATH=/usr/bin:/usr/bin/vendor_perl


### PR DESCRIPTION
`systemd` needs to have a `PATH` variable defined to find and run other executables as dependencies. Since we already have an environment file, and that environment file is read in the unit file (`photoview.service`), the simplest solution is to add `PATH` in the `.env` file.

I don't believe it will get in the way of the rest of the program that reads other env vars from that file.

I've tested on Arch. Docker, Ubuntu, etc. do still need to be tested.