### PR TITLE
Extend swipe functionality

### DIFF
--- a/ui/src/components/photoGallery/presentView/PresentNavigationOverlay.tsx
+++ b/ui/src/components/photoGallery/presentView/PresentNavigationOverlay.tsx
@@ -96,10 +96,17 @@ const PresentNavigationOverlay = ({
   }, [])
 
   const handlers = useSwipeable({
+    onSwipedDown: () => {
+      if (disableSaveCloseInHistory === true) {
+        dispatchMedia({ type: 'closePresentMode' })
+      } else {
+        closePresentModeAction({ dispatchMedia })
+      }
+    },
     onSwipedLeft: () => dispatchMedia({ type: 'nextImage' }),
     onSwipedRight: () => dispatchMedia({ type: 'previousImage' }),
     preventScrollOnSwipe: false,
-    trackMouse: false,
+    trackMouse: true,
   })
 
   return (
@@ -109,38 +116,38 @@ const PresentNavigationOverlay = ({
         onMouseMove.current && onMouseMove.current()
       }}
     >
-    <div {...handlers}>
-      {children}
-      <NavigationButton
-        aria-label="Previous image"
-        className={hide ? 'hide' : undefined}
-        align="left"
-        onClick={() => dispatchMedia({ type: 'previousImage' })}
-      >
-        <PrevIcon />
-      </NavigationButton>
-      <NavigationButton
-        aria-label="Next image"
-        className={hide ? 'hide' : undefined}
-        align="right"
-        onClick={() => dispatchMedia({ type: 'nextImage' })}
-      >
-        <NextIcon />
-      </NavigationButton>
-      <ExitButton
-        aria-label="Exit presentation mode"
-        className={hide ? 'hide' : undefined}
-        onClick={() => {
-          if (disableSaveCloseInHistory === true) {
-            dispatchMedia({ type: 'closePresentMode' })
-          } else {
-            closePresentModeAction({ dispatchMedia })
-          }
-        }}
-      >
-        <ExitIcon />
-      </ExitButton>
-    </div>
+      <div {...handlers} data-testid="swipe-component">
+        {children}
+        <NavigationButton
+          aria-label="Previous image"
+          className={hide ? 'hide' : undefined}
+          align="left"
+          onClick={() => dispatchMedia({ type: 'previousImage' })}
+        >
+          <PrevIcon />
+        </NavigationButton>
+        <NavigationButton
+          aria-label="Next image"
+          className={hide ? 'hide' : undefined}
+          align="right"
+          onClick={() => dispatchMedia({ type: 'nextImage' })}
+        >
+          <NextIcon />
+        </NavigationButton>
+        <ExitButton
+          aria-label="Exit presentation mode"
+          className={hide ? 'hide' : undefined}
+          onClick={() => {
+            if (disableSaveCloseInHistory === true) {
+              dispatchMedia({ type: 'closePresentMode' })
+            } else {
+              closePresentModeAction({ dispatchMedia })
+            }
+          }}
+        >
+          <ExitIcon />
+        </ExitButton>
+      </div>
     </StyledOverlayContainer>
   )
 }


### PR DESCRIPTION
On its own, this is a very simple addition to the swipe functionality on touch screen compatible devices, allowing for a swipe down to close the main image view. However, it did leave me wondering whether it'd be possible to extend the functionality of the image viewer itself.

There's a couple of open issues regarding zooming in on the single photo viewer (#217 and #236 ) - if https://github.com/FormidableLabs/react-swipeable/issues/244 is to be believed, the swipe overlay on the media can easily handle a double-click/tap to zoom event. The main problem then is figuring out a simple way to actually show the media at 100% size, and allow the user to navigate around whilst zoomed in, without the existing overlay (buttons and swipe gestures) getting in the way. 

[On a separate note, I do intend to implement a test for the react-swipeable component - identifying the element isn't a problem, but testing-library/react doesn't natively support a swipe gesture. I'll figure it out before adding any more swipe functionality though]