### PR TITLE
Restyle titles and spacing in timeline gallery

### DIFF
--- a/ui/src/components/photoGallery/MediaThumbnail.tsx
+++ b/ui/src/components/photoGallery/MediaThumbnail.tsx
@@ -9,7 +9,7 @@ const MediaContainer = styled.div`
   flex-grow: 1;
   flex-basis: 0;
   height: 200px;
-  margin: 4px;
+  margin: 4px 2px;
   background-color: #eee;
   position: relative;
   overflow: hidden;
@@ -214,7 +214,7 @@ export const MediaPlaceholder = styled.div`
   flex-grow: 1;
   height: 200px;
   width: 300px;
-  margin: 4px;
+  margin: 4px 2px;
   background-color: #eee;
   position: relative;
 `

--- a/ui/src/components/timelineGallery/TimelineGroupAlbum.tsx
+++ b/ui/src/components/timelineGallery/TimelineGroupAlbum.tsx
@@ -76,7 +76,9 @@ const TimelineGroupAlbum = ({
   return (
     <div className="mx-2">
       <Link to={`/album/${albumID}`} className="hover:underline">
-        {albumTitle}
+        <span className="text-sm text-gray-600 dark:text-gray-400">
+          {albumTitle}
+        </span>
       </Link>
       <div className="flex flex-wrap items-center relative -mx-1 overflow-hidden">
         {mediaElms}

--- a/ui/src/components/timelineGallery/TimelineGroupDate.tsx
+++ b/ui/src/components/timelineGallery/TimelineGroupDate.tsx
@@ -46,7 +46,7 @@ const TimelineGroupDate = ({
 
   return (
     <div className="mx-3 mb-2">
-      <div className="text-xl m-0 -mb-2">{formattedDate}</div>
+      <div className="text-lg font-bold m-0 -mb-2">{formattedDate}</div>
       <div className="flex flex-wrap -mx-2 my-0">{albumGroupElms}</div>
     </div>
   )


### PR DESCRIPTION
Restyle the titles and album names to look a bit better, and decrease the horizontal spacing between photos in the same album.

Before:
![Before](https://user-images.githubusercontent.com/32670283/194431205-c6bac979-795a-4010-9711-c668e2c4134a.png)


After:
![After](https://user-images.githubusercontent.com/32670283/194431214-099d59aa-1bf8-45e1-85ef-f8ac600b70b6.png)
