### PR TITLE
fix transaction already commited error

### DIFF
--- a/api/scanner/media_scan.go
+++ b/api/scanner/media_scan.go
@@ -1,0 +1,40 @@
+package scanner
+
+import (
+	"github.com/photoview/photoview/api/graphql/models"
+	"github.com/photoview/photoview/api/scanner/media_encoding"
+	"github.com/photoview/photoview/api/scanner/scanner_task"
+	"github.com/photoview/photoview/api/scanner/scanner_tasks"
+	"github.com/pkg/errors"
+)
+
+func scanMedia(ctx scanner_task.TaskContext, media *models.Media, mediaData *media_encoding.EncodeMediaData, mediaIndex int, mediaTotal int) error {
+	newCtx, err := scanner_tasks.Tasks.BeforeProcessMedia(ctx, mediaData)
+	if err != nil {
+		return errors.Wrapf(err, "before process media (%s)", media.Path)
+	}
+
+	mediaCachePath, err := media.CachePath()
+	if err != nil {
+		return errors.Wrapf(err, "cache directory error (%s)", media.Path)
+	}
+
+	transactionError := newCtx.DatabaseTransaction(func(ctx scanner_task.TaskContext) error {
+		updatedURLs, err := scanner_tasks.Tasks.ProcessMedia(newCtx, mediaData, mediaCachePath)
+		if err != nil {
+			return errors.Wrapf(err, "process media (%s)", media.Path)
+		}
+
+		if err = scanner_tasks.Tasks.AfterProcessMedia(newCtx, mediaData, updatedURLs, mediaIndex, mediaTotal); err != nil {
+			return errors.Wrap(err, "after process media")
+		}
+
+		return nil
+	})
+
+	if transactionError != nil {
+		return errors.Wrap(transactionError, "process media database transaction")
+	}
+
+	return nil
+}

--- a/api/scanner/scanner_media.go
+++ b/api/scanner/scanner_media.go
@@ -10,7 +10,6 @@ import (
 	"github.com/photoview/photoview/api/scanner/media_encoding"
 	"github.com/photoview/photoview/api/scanner/scanner_cache"
 	"github.com/photoview/photoview/api/scanner/scanner_task"
-	"github.com/photoview/photoview/api/scanner/scanner_tasks"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 )
@@ -82,24 +81,8 @@ func ProcessSingleMedia(db *gorm.DB, media *models.Media) error {
 	media_data := media_encoding.NewEncodeMediaData(media)
 
 	task_context := scanner_task.NewTaskContext(context.Background(), db, &album, album_cache)
-	new_ctx, err := scanner_tasks.Tasks.BeforeProcessMedia(task_context, &media_data)
-	if err != nil {
-		return err
-	}
-
-	mediaCachePath, err := media.CachePath()
-	if err != nil {
-		return err
-	}
-
-	updated_urls, err := scanner_tasks.Tasks.ProcessMedia(new_ctx, &media_data, mediaCachePath)
-	if err != nil {
-		return err
-	}
-
-	err = scanner_tasks.Tasks.AfterProcessMedia(new_ctx, &media_data, updated_urls, 0, 1)
-	if err != nil {
-		return err
+	if err := scanMedia(task_context, media, &media_data, 0, 1); err != nil {
+		return errors.Wrap(err, "single media scan")
 	}
 
 	return nil


### PR DESCRIPTION
I encountered with the following error:

> 2023/02/05 07:33:00 /app/scanner/face_detection/face_detector.go:92 sql: transaction has already been committed or rolled back
> [0.042ms] [rows:0] SELECT * FROM `media` WHERE `media`.`id` = 823 ORDER BY `media`.`id` LIMIT 1
> 2023/02/05 07:33:00 ERROR: Error detecting faces in image (/photos/Borzsony2017/DSC_0028.NEF): sql: transaction has already been committed or rolled back

It turned out it comes from the api/routes/photos.go

I found a very similar code in album_scanner.go.
The difference I saw was that while in the single photo request the
transaction passed to the `scanner_tasks.Tasks.BeforeProcessMedia` call,
in the album_scann.go the transaction created after this call and
created from the context which returned by `BeforeProcessMedia`.

Another difference was that in the `ProcessSingleMedia` call the
`AfterProcessMedia` call was called with the same - db transaction -
context, in the album_scanner it was called outside of the transaction.

I changed the logic by merging the two behavior:
Create the transaction from the context of `BeforeProcessMedia` and also
use the transaction context in the `AfterProcessMedia`.
After the change the error disappeared.

So to have it in a common place I extracted that logic into a function
and use for both the single photo request and in the album scanner.

I did not go more deeper to find out what's going on with the context
under the hood.
