### PR TITLE
Limit thumbnail size of small original photo in new branch

### DIFF
--- a/api/scanner/media_encoding/media_utils/photo_dimensions.go
+++ b/api/scanner/media_encoding/media_utils/photo_dimensions.go
@@ -48,6 +48,11 @@ func (dimensions *PhotoDimensions) ThumbnailScale() PhotoDimensions {
 		height = 1024
 	}
 
+	if width > dimensions.Width {
+		width = dimensions.Width
+		height = dimensions.Height
+	}
+
 	return PhotoDimensions{
 		Width:  width,
 		Height: height,


### PR DESCRIPTION
This is a new pull request of Limit thumbnail size of small original photo, which was part of the old pull request https://github.com/photoview/photoview/pull/790. I commit it to a new branch other than master. The old one will be closed soon.