### PR TITLE
Use Clean() but not Abs() to prevent directory traversal

### DIFF
--- a/api/routes/spa.go
+++ b/api/routes/spa.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 )
 
@@ -27,20 +28,14 @@ func NewSpaHandler(staticPath string, indexPath string) SpaHandler {
 // file located at the index path on the SPA handler will be served. This
 // is suitable behavior for serving an SPA (single page application).
 func (h SpaHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// get the absolute path to prevent directory traversal
-	path, err := filepath.Abs(r.URL.Path)
-	if err != nil {
-		// if we failed to get the absolute path respond with a 400 bad request
-		// and stop
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
+	// get the clean path to prevent directory traversal
+	servePath := path.Clean(r.URL.Path)
 
 	// prepend the path with the path to the static directory
-	path = filepath.Join(h.staticPath, path)
+	servePath = filepath.Join(h.staticPath, servePath)
 
 	// check whether a file exists at the given path
-	_, err = os.Stat(path)
+	_, err := os.Stat(servePath)
 	if os.IsNotExist(err) {
 		// file does not exist, serve index.html
 		http.ServeFile(w, r, filepath.Join(h.staticPath, h.indexPath))


### PR DESCRIPTION
The old code use filepath.Abs() to prevent directory traversal, and that's not so good.
The code of filepath.Abs() is below,
```
// Abs returns an absolute representation of path.
// If the path is not absolute it will be joined with the current
// working directory to turn it into an absolute path. The absolute
// path name for a given file is not guaranteed to be unique.
// Abs calls Clean on the result.
func Abs(path string) (string, error) {
	return abs(path)
}

func unixAbs(path string) (string, error) {
	if IsAbs(path) {
		return Clean(path), nil     // When the input path is absolute, the Abs() just call Clean() to make it safe. 
	}
	wd, err := os.Getwd()
	if err != nil {
		return "", err
	}
	return Join(wd, path), nil        // When not, the Abs() add the work directory before the it.
}

```
I think adding the working directory of application photoview before the input path is no sense. And because the Clean() isn't called after adding the working directory before input path, the .. is still in the path, and directory traversal doesn't be prevented.
So, I think no matter the input path is absolute or not, Clean() should be calles, and that's enough. BTW, because the input path is URL path but not file path, I use path.Clean() but not filepath.Clean() to it.