### PR TITLE
Add support to parse DateTimes with UTC+Offset

### DIFF
--- a/api/scanner/exif/exif_parser_external.go
+++ b/api/scanner/exif/exif_parser_external.go
@@ -119,6 +119,13 @@ func (p *externalExifParser) ParseExif(media_path string) (returnExif *models.Me
 			if err == nil {
 				found_exif = true
 				newExif.DateShot = &dateTime
+			} else {
+				layoutWithOffset := "2006:01:02 15:04:05+02:00"
+				dateTime, err = time.Parse(layoutWithOffset, date)
+				if err == nil {
+					found_exif = true
+					newExif.DateShot = &dateTime
+				}	
 			}
 			break
 		}


### PR DESCRIPTION
The former change added support for various Dates in a specific order but did not take the UTC+Offset into account.