### PR TITLE
Reject face modification from non-admin user

### DIFF
--- a/ui/src/Pages/PeoplePage/PeoplePage.tsx
+++ b/ui/src/Pages/PeoplePage/PeoplePage.tsx
@@ -9,6 +9,7 @@ import FaceCircleImage from './FaceCircleImage'
 import useScrollPagination from '../../hooks/useScrollPagination'
 import PaginateLoader from '../../components/PaginateLoader'
 import { useTranslation } from 'react-i18next'
+import { useIsAdmin } from '../../components/routes/AuthorizedRoute'
 import {
   setGroupLabel,
   setGroupLabelVariables,
@@ -122,6 +123,7 @@ export const FaceDetails = ({
   const { t } = useTranslation()
   const [inputValue, setInputValue] = useState(group.label ?? '')
   const inputRef = createRef<HTMLInputElement>()
+  const isAdmin = useIsAdmin()
 
   const [setGroupLabel, { loading }] = useMutation<
     setGroupLabel,
@@ -163,7 +165,7 @@ export const FaceDetails = ({
           'whitespace-nowrap inline-block overflow-hidden overflow-clip'
         )}
         labeled={!!group.label}
-        onClick={() => setEditLabel(true)}
+        onClick={isAdmin ? () => setEditLabel(true) : () => {}}
       >
         <FaceImagesCount>{group.imageFaceCount}</FaceImagesCount>
         <button className="">

--- a/ui/src/Pages/PeoplePage/SingleFaceGroup/FaceGroupTitle.tsx
+++ b/ui/src/Pages/PeoplePage/SingleFaceGroup/FaceGroupTitle.tsx
@@ -6,6 +6,7 @@ import React, {
   KeyboardEventHandler,
 } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useIsAdmin } from '../../../components/routes/AuthorizedRoute'
 import { isNil } from '../../../helpers/utils'
 import { Button, TextField } from '../../../primitives/form/Input'
 import { MY_FACES_QUERY, SET_GROUP_LABEL_MUTATION } from '../PeoplePage'
@@ -24,6 +25,7 @@ type FaceGroupTitleProps = {
 
 const FaceGroupTitle = ({ faceGroup }: FaceGroupTitleProps) => {
   const { t } = useTranslation()
+  const isAdmin = useIsAdmin()
 
   const [editLabel, setEditLabel] = useState(false)
   const [inputValue, setInputValue] = useState(faceGroup?.label ?? '')
@@ -136,28 +138,30 @@ const FaceGroupTitle = ({ faceGroup }: FaceGroupTitleProps) => {
     <>
       <div>
         <div className="mb-2">{title}</div>
-        <ul className="flex gap-2 flex-wrap mb-6">
-          <li>
-            <Button onClick={() => setEditLabel(true)}>
-              {t('people_page.action_label.change_label', 'Change label')}
-            </Button>
-          </li>
-          <li>
-            <Button onClick={() => setMergeModalOpen(true)}>
-              {t('people_page.action_label.merge_people', 'Merge people')}
-            </Button>
-          </li>
-          <li>
-            <Button onClick={() => setDetachModalOpen(true)}>
-              {t('people_page.action_label.detach_images', 'Detach images')}
-            </Button>
-          </li>
-          <li>
-            <Button onClick={() => setMoveModalOpen(true)}>
-              {t('people_page.action_label.move_faces', 'Move faces')}
-            </Button>
-          </li>
-        </ul>
+        {isAdmin && (
+          <ul className="flex gap-2 flex-wrap mb-6">
+            <li>
+              <Button onClick={() => setEditLabel(true)}>
+                {t('people_page.action_label.change_label', 'Change label')}
+              </Button>
+            </li>
+            <li>
+              <Button onClick={() => setMergeModalOpen(true)}>
+                {t('people_page.action_label.merge_people', 'Merge people')}
+              </Button>
+            </li>
+            <li>
+              <Button onClick={() => setDetachModalOpen(true)}>
+                {t('people_page.action_label.detach_images', 'Detach images')}
+              </Button>
+            </li>
+            <li>
+              <Button onClick={() => setMoveModalOpen(true)}>
+                {t('people_page.action_label.move_faces', 'Move faces')}
+              </Button>
+            </li>
+          </ul>
+        )}
       </div>
       {modals}
     </>

--- a/ui/src/components/sidebar/MediaSidebar/MediaSidebarPeople.tsx
+++ b/ui/src/components/sidebar/MediaSidebar/MediaSidebarPeople.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useIsAdmin } from '../../../components/routes/AuthorizedRoute'
 import { Link, useNavigate } from 'react-router-dom'
 import FaceCircleImage from '../../../Pages/PeoplePage/FaceCircleImage'
 import { SidebarSection, SidebarSectionTitle } from '../SidebarComponents'
@@ -60,6 +61,7 @@ const PersonMoreMenu = ({
   className,
 }: PersonMoreMenuProps) => {
   const { t } = useTranslation()
+  const isAdmin = useIsAdmin()  
 
   const [mergeModalOpen, setMergeModalOpen] = useState(false)
   const [moveModalOpen, setMoveModalOpen] = useState(false)
@@ -113,40 +115,42 @@ const PersonMoreMenu = ({
 
   return (
     <>
-      <Menu
-        as="div"
-        className={tailwindClassNames('relative inline-block', className)}
-      >
-        <Menu.Button as={Button} className="px-1.5 py-1.5 align-middle ml-1">
-          <PeopleDotsIcon className="text-gray-500" />
-        </Menu.Button>
-        <Menu.Items className="">
-          <ArrowPopoverPanel width={120} flipped={menuFlipped}>
-            <PersonMoreMenuItem
-              onClick={() => setChangeLabel(true)}
-              className="border-b"
-              label={t('people_page.action_label.change_label', 'Change label')}
-            />
-            <PersonMoreMenuItem
-              onClick={() => setMergeModalOpen(true)}
-              className="border-b"
-              label={t('sidebar.people.action_label.merge_face', 'Merge face')}
-            />
-            <PersonMoreMenuItem
-              onClick={() => detachImageFace()}
-              className="border-b"
-              label={t(
-                'sidebar.people.action_label.detach_image',
-                'Detach image'
-              )}
-            />
-            <PersonMoreMenuItem
-              onClick={() => setMoveModalOpen(true)}
-              label={t('sidebar.people.action_label.move_face', 'Move face')}
-            />
-          </ArrowPopoverPanel>
-        </Menu.Items>
-      </Menu>
+      {isAdmin && (
+        <Menu
+          as="div"
+          className={tailwindClassNames('relative inline-block', className)}
+        >
+          <Menu.Button as={Button} className="px-1.5 py-1.5 align-middle ml-1">
+            <PeopleDotsIcon className="text-gray-500" />
+          </Menu.Button>
+          <Menu.Items className="">
+            <ArrowPopoverPanel width={120} flipped={menuFlipped}>
+              <PersonMoreMenuItem
+                onClick={() => setChangeLabel(true)}
+                className="border-b"
+                label={t('people_page.action_label.change_label', 'Change label')}
+              />
+              <PersonMoreMenuItem
+                onClick={() => setMergeModalOpen(true)}
+                className="border-b"
+                label={t('sidebar.people.action_label.merge_face', 'Merge face')}
+              />
+              <PersonMoreMenuItem
+                onClick={() => detachImageFace()}
+                className="border-b"
+                label={t(
+                  'sidebar.people.action_label.detach_image',
+                  'Detach image'
+                )}
+              />
+              <PersonMoreMenuItem
+                onClick={() => setMoveModalOpen(true)}
+                label={t('sidebar.people.action_label.move_face', 'Move face')}
+              />
+            </ArrowPopoverPanel>
+          </Menu.Items>
+        </Menu>
+      )}
       {modals}
     </>
   )


### PR DESCRIPTION
Now both admin and non-admin user can modify face reorganization results of the photos. For example, the non-admin user can change the face name, merge the face group, and so on. I think maybe it is better that only allow the admin user has the write permission, and keep the non-admin user in read-only mode. 