### PR TITLE
Initial setup login page should hide password input

### DIFF
--- a/ui/src/Pages/LoginPage/InitialSetupPage.tsx
+++ b/ui/src/Pages/LoginPage/InitialSetupPage.tsx
@@ -119,6 +119,7 @@ const InitialSetupPage = () => {
                 ? 'Please enter a password'
                 : undefined
             }
+            type="password"
           />
           <TextField
             wrapperClassName="my-4"


### PR DESCRIPTION
The form field for password `type` property wasn't set correctly, so passwords would display in browser as user typed them in