### PR TITLE
Don't stop scanning album on media fail

### DIFF
--- a/api/scanner/scanner_album.go
+++ b/api/scanner/scanner_album.go
@@ -103,7 +103,7 @@ func ScanAlbum(ctx scanner_task.TaskContext) error {
 		mediaData := media_encoding.NewEncodeMediaData(media)
 
 		if err := scanMedia(ctx, media, &mediaData, i, len(albumMedia)); err != nil {
-			return errors.Wrap(err, "album scan")
+			log.Println("Media scan failed: ", err)
 		}
 	}
 


### PR DESCRIPTION
Stopping scan after a media failed is also skipping all following files. The album will only show content up to the failed item with no simple option to recover from this situation.

Instead when continuing the scan the whole album will be scanned and failed items will show up with a missing thumbnail. That way at least everything that can be scanned is scanned, and failed media items might still show fine in the original (e.g. Samsung panorama photos).