### PR TITLE
Prepend missing key CreationDate to createDateKeys

### DIFF
--- a/api/scanner/exif/exif_parser_external.go
+++ b/api/scanner/exif/exif_parser_external.go
@@ -112,7 +112,7 @@ func (p *externalExifParser) ParseExif(media_path string) (returnExif *models.Me
 	}
 
 	//Get time of photo
-	createDateKeys := []string{"DateTimeOriginal", "CreateDate", "TrackCreateDate", "MediaCreateDate", "FileCreateDate", "ModifyDate", "TrackModifyDate", "MediaModifyDate", "FileModifyDate"}
+	createDateKeys := []string{"CreationDate", "DateTimeOriginal", "CreateDate", "TrackCreateDate", "MediaCreateDate", "FileCreateDate", "ModifyDate", "TrackModifyDate", "MediaModifyDate", "FileModifyDate"}
 	for _, createDateKey := range createDateKeys {
 		date, err := fileInfo.GetString(createDateKey)
 		if err == nil {


### PR DESCRIPTION
Creation Date (CreationDate) was missing in the list of possible keys.
This might result into wrong results when it comes to date time parsing while scanning/processing new videos.