### PR TITLE
Fix invalid UTC offset during datetime parsing

### DIFF
--- a/api/scanner/exif/exif_parser_external.go
+++ b/api/scanner/exif/exif_parser_external.go
@@ -122,12 +122,12 @@ func (p *externalExifParser) ParseExif(media_path string) (returnExif *models.Me
 				found_exif = true
 				newExif.DateShot = &dateTime
 			} else {
-				layoutWithOffset := "2006:01:02 15:04:05+02:00"
+				layoutWithOffset := "2006:01:02 15:04:05-07:00"
 				dateTime, err = time.Parse(layoutWithOffset, date)
 				if err == nil {
 					found_exif = true
 					newExif.DateShot = &dateTime
-				}	
+				}
 			}
 			break
 		}


### PR DESCRIPTION
In my initial request a few month's ago, i passed an invalid UTC offset format.
+02:00 must be -07:00

See [here](https://go.dev/src/time/format.go) line 68