### PR TITLE
Remove login page non-empty password requirement

### DIFF
--- a/ui/src/Pages/LoginPage/LoginPage.tsx
+++ b/ui/src/Pages/LoginPage/LoginPage.tsx
@@ -96,12 +96,7 @@ const LoginForm = () => {
         className="w-full"
         type="password"
         label={t('login_page.field.password', 'Password')}
-        {...register('password', { required: true })}
-        error={
-          formErrors.password?.type == 'required'
-            ? 'Please enter a password'
-            : undefined
-        }
+        {...register('password', { required: false })}
       />
       <input
         type="submit"

--- a/ui/src/Pages/LoginPage/LoginPage.tsx
+++ b/ui/src/Pages/LoginPage/LoginPage.tsx
@@ -96,7 +96,7 @@ const LoginForm = () => {
         className="w-full"
         type="password"
         label={t('login_page.field.password', 'Password')}
-        {...register('password', { required: false })}
+        {...register('password')}
       />
       <input
         type="submit"


### PR DESCRIPTION
Passwords are allowed to be empty in the database, but the login page fails form validation if an empty password is entered.
This change _only_ removes that validation. This isn't a great solution, but will allow password-less users in the short term.

This "bug" / feature request has been mentioned a few times:
- [#478](https://github.com/photoview/photoview/issues/478)
- [#659](https://github.com/photoview/photoview/issues/659)
- [#174](https://github.com/photoview/photoview/issues/174) (semi-related)

More extensive changes to the authentication system have been discussed in [#624](https://github.com/photoview/photoview/issues/624)