### PR TITLE
Fix RAW file support for docker non-root users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,10 @@ RUN apt update \
   && apt install -y curl gpg libdlib19.1 ffmpeg exiftool libheif1
 
 # Install Darktable if building for a supported architecture
+# And create darktable directories for non-root users
 RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ] || [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
-  apt install -y darktable; fi
+  apt install -y darktable && \
+  mkdir -p /.cache/darktable /.config/darktable; fi
 
 # Remove build dependencies and cleanup
 RUN apt purge -y gpg \


### PR DESCRIPTION
Supporting RAW file formats requires running `darktable-cli`, which fails in docker for non-root users with the following error:
```bash
path lookup '/.config/darktable' fails with: 'No such file or directory'
```
Both `/.config/darktable` and `/.cache/darktable` must be present to run `darktable-cli`. Normally, these directories would be silently created on first run, but non-root users don't have permission to create directories.

This change creates those directories in the docker image.