### PR TITLE
Fix custom basepath in React components

### DIFF
--- a/ui/public/manifest.json
+++ b/ui/public/manifest.json
@@ -8,15 +8,15 @@
   "background_color": "white",
   "icons": [
     {
-      "src": "/photoview/logo192.png",
+      "src": "/assets/logo192.png",
       "sizes": "192x192"
     },
     {
-      "src": "/photoview/logo512.png",
+      "src": "/assets/logo512.png",
       "sizes": "512x512"
     },
     {
-      "src": "/photoview/photoview-logo.svg",
+      "src": "/assets/photoview-logo.svg",
       "sizes": "150x150"
     }
   ]

--- a/ui/public/manifest.json
+++ b/ui/public/manifest.json
@@ -8,15 +8,15 @@
   "background_color": "white",
   "icons": [
     {
-      "src": "/assets/logo192.png",
+      "src": "/photoview/logo192.png",
       "sizes": "192x192"
     },
     {
-      "src": "/assets/logo512.png",
+      "src": "/photoview/logo512.png",
       "sizes": "512x512"
     },
     {
-      "src": "/assets/photoview-logo.svg",
+      "src": "/photoview/photoview-logo.svg",
       "sizes": "150x150"
     }
   ]

--- a/ui/src/components/photoGallery/ProtectedMedia.tsx
+++ b/ui/src/components/photoGallery/ProtectedMedia.tsx
@@ -13,7 +13,7 @@ const placeholder =
 const getProtectedUrl = (url?: string) => {
   if (url == undefined) return undefined
 
-  const imgUrl = new URL(url, location.origin)
+  const imgUrl = new URL(`${import.meta.env.BASE_URL}/${url}`, location.origin)
 
   const tokenRegex = location.pathname.match(/^\/share\/([\d\w]+)(\/?.*)$/)
   if (tokenRegex) {

--- a/ui/src/components/photoGallery/ProtectedMedia.tsx
+++ b/ui/src/components/photoGallery/ProtectedMedia.tsx
@@ -13,7 +13,10 @@ const placeholder =
 const getProtectedUrl = (url?: string) => {
   if (url == undefined) return undefined
 
-  const imgUrl = new URL(`${import.meta.env.BASE_URL}/${url}`, location.origin)
+  const imgUrl = new URL(
+    `${import.meta.env.BASE_URL}${url}`.replace(/\/\//g, '/'),
+    location.origin
+  )
 
   const tokenRegex = location.pathname.match(/^\/share\/([\d\w]+)(\/?.*)$/)
   if (tokenRegex) {

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -16,7 +16,7 @@ setupLocalization()
 
 const Main = () => (
   <ApolloProvider client={client}>
-    <Router>
+    <Router basename={import.meta.env.BASE_URL}>
       <SidebarProvider>
         <App />
       </SidebarProvider>


### PR DESCRIPTION
Partial fix for #834 that restores basic app functionality in case of building with `UI_PUBLIC_URL`. The `manifest.json` still contains hardcoded relative URLs. The service worker also doesn't work with custom basepath.