### PR TITLE
Faster start of video playback

### DIFF
--- a/api/scanner/media_encoding/executable_worker/executable_worker.go
+++ b/api/scanner/media_encoding/executable_worker/executable_worker.go
@@ -126,6 +126,7 @@ func (worker *FfmpegWorker) EncodeMp4(inputPath string, outputPath string) error
 		"-vcodec", "h264",
 		"-acodec", "aac",
 		"-vf", "scale='min(1080,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2",
+		"-movflags", "+faststart+use_metadata_tags",
 		outputPath,
 	}
 


### PR DESCRIPTION
Video playback starts faster in browsers if the [moov atom](https://en.wikipedia.org/wiki/MP4_file_format#Data_streams) is at the beginning of an `mp4` file.

Unfortunately, `ffmpeg` places the moov atom by default at the end of an mp4 output file.

To find out the order of `moov` and `mdat`, run
```bash
cd path/to/photoview/cache/
mp4file="$(find . -type f -name '*.mp4' | head -n1)"
ffmpeg -v "$mp4file" 2>&1 | grep -e type:\'mdat\' -e type:\'moov\'
# [mov,mp4,m4a,3gp,3g2,mj2 @ 0x564c02b9c5c0] type:'moov' parent:'root' sz: 4053902 40 472170316
# [mov,mp4,m4a,3gp,3g2,mj2 @ 0x564c02b9c5c0] type:'mdat' parent:'root' sz: 468116374 4053950 472170316
```
The moov atom in the example above is at the beginning of the MP4 file, which results in faster start of video playback in web UI.

Such files are produced by `photoview` built from this PR. A container image is also pushed to `docker.io/kabakaev/photoview:mp4-faststart`.

In contrast, `photoview` from master branch puts moov atom at the end of mp4 files. Hence, browser has to download a full video file before playing.

