### PR TITLE
recode videos incompatible with popular browsers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,15 +74,12 @@ WORKDIR /app
 COPY api/data /app/data
 
 RUN apt update \
-  # Required dependencies
-  && apt install -y curl gpg libdlib19.1 ffmpeg exiftool libheif1
-
-# Install Darktable if building for a supported architecture
-RUN if [ "${TARGETPLATFORM}" = "linux/amd64" ] || [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
-  apt install -y darktable; fi
-
-# Remove build dependencies and cleanup
-RUN apt purge -y gpg \
+  `# Required dependencies` \
+  && apt install -y curl gpg libdlib19.1 ffmpeg exiftool libheif1 \
+  `# Install Darktable if building for a supported architecture` \
+  && if [ "${TARGETPLATFORM}" = "linux/amd64" ] || [ "${TARGETPLATFORM}" = "linux/arm64" ]; then \
+    apt install -y darktable; fi \
+  && apt purge -y gpg \
   && apt autoremove -y \
   && apt clean \
   && rm -rf /var/lib/apt/lists/*

--- a/api/scanner/scanner_tasks/processing_tasks/sidecar_task.go
+++ b/api/scanner/scanner_tasks/processing_tasks/sidecar_task.go
@@ -34,7 +34,7 @@ func (t SidecarTask) AfterMediaFound(ctx scanner_task.TaskContext, media *models
 		return nil
 	}
 
-	var sideCarPath *string = nil
+	var sideCarPath *string
 	var sideCarHash *string = nil
 
 	sideCarPath = scanForSideCarFile(media.Path)


### PR DESCRIPTION
This PR fixes #606 and partly #387, except a remux of existing video stream.

@bobobo1618, can you give an example of video files worth remuxing?

My video archive has only a handful of records from a digital video camera, which saved H.264 video and AC3 audio in MPEGTS container. But even there, I'd prefer to spend some CPU time to re-encode that hardware-encoded H.264 stream through libx264 to avoid artifacts, improve compression (Main vs. High profile) and to validate the stream.

Another possible use case would be to remux videos in order to move the MP4 `moov` atom in front of `mdat` for faster start of video playback. But I guess it's better to prepare such a remux on-the-fly instead of on-disk caching.

Anyone willing to make use of this PR should remove the "original" media_urls and then press `Scan` button for the affected users.
For example, H.264-encoding of all google pixel videos can be triggered by this SQL statement:
1. Make backup of the database
2. `delete from media_urls where media_name LIKE 'PXL%.mp4' AND purpose=='original';`

A combined code of this PR and #883 is built and pushed to container registry at docker.io/kabakaev/photoview:recode-incompatible-video

@mawi675lr81, @ouafnico, @CorneliousJD, would you like to test your video files with this fixed version (avoid running on production though, or make a backup)?

The combined code is pushed at https://github.com/kabakaev/photoview/tree/recode-incompatible-video