### PR TITLE
add cross compile support for arm64 to amd64

### DIFF
--- a/docker/install_build_dependencies.sh
+++ b/docker/install_build_dependencies.sh
@@ -8,6 +8,7 @@ elif [ "$TARGETPLATFORM" == "linux/arm/v6" ] || [ "$TARGETPLATFORM" == "linux/ar
   dpkg --add-architecture armhf
   DEBIAN_ARCH='armhf'
 else
+  dpkg --add-architecture amd64
   DEBIAN_ARCH='amd64'
 fi
 
@@ -22,6 +23,10 @@ elif [ "$DEBIAN_ARCH" == "armhf" ]; then
   apt-get install -y \
     g++-arm-linux-gnueabihf \
     libc6-dev-armhf-cross
+else
+  apt-get install -y \
+    g++-x86-64-linux-gnu \
+    libc6-dev-amd64-cross
 fi
 
 # Install Golang


### PR DESCRIPTION
## I'm using a free Oracle Cloud Arm64 instance as the building platform, with this error ```E: Unable to locate package libdlib-dev:amd64 ```,  solved like this. 

<img width="966" alt="Weixin Image_20230903102832" src="https://github.com/photoview/photoview/assets/9974073/197d2224-a15b-48ac-93fb-8d1d2689ada6">
