### PR TITLE
reordered cli arguments for ffmpeg to improve speed to generate thumbnails of videos

### DIFF
--- a/api/scanner/media_encoding/executable_worker/executable_worker.go
+++ b/api/scanner/media_encoding/executable_worker/executable_worker.go
@@ -143,12 +143,12 @@ func (worker *FfmpegWorker) EncodeVideoThumbnail(inputPath string, outputPath st
 	thumbnailOffsetSeconds := fmt.Sprintf("%d", int(probeData.Format.DurationSeconds*0.25))
 
 	args := []string{
+		"-ss", thumbnailOffsetSeconds, // grab frame at time offset
 		"-i",
 		inputPath,
 		"-vframes", "1", // output one frame
 		"-an", // disable audio
 		"-vf", "scale='min(1024,iw)':'min(1024,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2",
-		"-ss", thumbnailOffsetSeconds, // grab frame at time offset
 		outputPath,
 	}
 


### PR DESCRIPTION
Currently, Photoview uses output seeking of ffmpeg to generate thumbails of videos. This is a very time consuming behavior and not necessary since ffmpeg 2.1 (which is very outdated).

Reordering the arguments in the way this PR introduces changes the behavior to input seeking which (instead of encoding the full video) just seeks through the video based on key frames.

For a better and more in depth explanation of the behavior and the pros and cons see the official ffmpeg documentation (https://trac.ffmpeg.org/wiki/Seeking#Inputseeking).

Love to get feedback on this PR (I understand that the maintainer has paused the project, but I'd be happy to hear already what @kkovaletp thinks).