### PR TITLE
add ImageMagick Support

### DIFF
--- a/api/scanner/media_encoding/encode_photo.go
+++ b/api/scanner/media_encoding/encode_photo.go
@@ -115,6 +115,11 @@ func (img *EncodeMediaData) EncodeHighRes(outputPath string) error {
 			if err != nil {
 				return err
 			}
+		} else if executable_worker.ImageMagickCli.IsInstalled(){
+			err := executable_worker.ImageMagickCli.EncodeJpeg(img.Media.Path, outputPath, 70)
+			if err != nil {
+				return err
+			}
 		} else {
 			return errors.New("could not convert photo as no RAW converter was found")
 		}

--- a/api/scanner/media_type/media_type.go
+++ b/api/scanner/media_type/media_type.go
@@ -263,6 +263,10 @@ func (imgType *MediaType) IsSupported() bool {
 	if executable_worker.FfmpegCli.IsInstalled() && imgType.IsVideo() {
 		return true
 	}
+	
+	if executable_worker.ImageMagickCli.IsInstalled() && imgType.IsRaw() {
+		return true
+	}
 
 	return false
 }


### PR DESCRIPTION
Fixes #923 In the current `RAW` format support, which is supported by `Darktable`, but on some machines the package may not be installed, I added the `ImageMagick` package as a `Darktable` alternative to support the `RAW` format

@ kkovaletp I compiled the test on your branch.