### PR TITLE
fix false trigger of DB migration on sqlite

### DIFF
--- a/api/database/migration_exif.go
+++ b/api/database/migration_exif.go
@@ -22,7 +22,7 @@ func migrate_exif_fields(db *gorm.DB) error {
 		for _, exifCol := range mediaExifColumns {
 			if exifCol.Name() == "exposure" {
 				switch exifCol.DatabaseTypeName() {
-				case "double", "numeric", "real", "bigint":
+				case "double", "numeric", "real", "bigint", "integer":
 					// correct type, do nothing
 				default:
 					// do migration
@@ -34,7 +34,7 @@ func migrate_exif_fields(db *gorm.DB) error {
 
 			if exifCol.Name() == "flash" {
 				switch exifCol.DatabaseTypeName() {
-				case "double", "numeric", "real", "bigint":
+				case "double", "numeric", "real", "bigint", "integer":
 					// correct type, do nothing
 				default:
 					// do migration


### PR DESCRIPTION
The Go `int64` type maps to `integer` [SQLite column affinity](https://sqlite.org/datatype3.html#affinity_name_examples).

Hence, if `exifCol.DatabaseTypeName()` returns `integer`, then no migration is needed.

This PR fixes #768.

FYI [gechandesu](https://github.com/gechandesu), the container image of a master branch with the fixed sqlite migration is pushed to docker.io/kabakaev/photoview:79e44d0