### PR TITLE
Fix timeline order with sqlite3. It should be ordered as MySQL and PGSQL like `(year, month, day)`.

### DIFF
--- a/api/graphql/models/actions/timeline_actions.go
+++ b/api/graphql/models/actions/timeline_actions.go
@@ -24,7 +24,7 @@ func MyTimeline(db *gorm.DB, user *models.User, paginate *models.Pagination, onl
 			Order("media.date_shot DESC")
 	case drivers.SQLITE:
 		query = query.
-			Order("strftime('%j', media.date_shot) DESC"). // convert to day of year 001-366
+			Order("strftime('%Y-%m-%d', media.date_shot) DESC"). // convert to YYYY-MM-DD
 			Order("albums.title ASC").
 			Order("TIME(media.date_shot) DESC")
 	default:


### PR DESCRIPTION
When using `sqlite` as database, `Timeline` shows media ordering by the album's day of the year. If I have albums like:

- Album1 on 2020-12-31
- Album2 on 2021-01-01

My timeline shows media in `Album1` first, then media in `Album2`, even `Album2` is more recent.

I see `PostgreSQL` and `MySQL` are ordering with `(year, month, day)`, which is reasonable. Only `sqlite` is ordering with `(the day of the year)`. I don't know why `sqlite` has a special behavior here.

This patch matches the sqlite behavior with other databases.