### PR TITLE
Allow SQLite to accept several connections at the same time

### DIFF
--- a/api/database/database.go
+++ b/api/database/database.go
@@ -63,6 +63,8 @@ func GetSqliteAddress(path string) (*url.URL, error) {
 	queryValues.Add("cache", "shared")
 	queryValues.Add("mode", "rwc")
 	// queryValues.Add("_busy_timeout", "60000") // 1 minute
+	queryValues.Add("_journal_mode", "WAL") // Write-Ahead Logging (WAL) mode
+	queryValues.Add("_locking_mode", "NORMAL") // allows concurrent reads and writes
 	address.RawQuery = queryValues.Encode()
 
 	// log.Panicf("%s", address.String())


### PR DESCRIPTION
Configure SQLite to work in multi-connection mode, so it is not locked when scanner runs a job.
This fixes the issue #846.