### PR TITLE
Optimize user's album filter.

### DIFF
--- a/api/graphql/models/actions/album_actions_test.go
+++ b/api/graphql/models/actions/album_actions_test.go
@@ -12,7 +12,7 @@ import (
 func TestAlbumPath(t *testing.T) {
 	db := test_utils.DatabaseTest(t)
 
-	album := models.Album{
+	album := &models.Album{
 		Title: "Three",
 		Path:  "/one/two/three",
 		ParentAlbum: &models.Album{
@@ -30,9 +30,9 @@ func TestAlbumPath(t *testing.T) {
 	user, err := models.RegisterUser(db, "user", nil, false)
 	assert.NoError(t, err)
 
-	db.Model(&user).Association("Albums").Append(album.ParentAlbum.ParentAlbum)
+	db.Model(&user).Association("Albums").Append(album.ParentAlbum.ParentAlbum, album.ParentAlbum, album)
 
-	albumPath, err := actions.AlbumPath(db, user, &album)
+	albumPath, err := actions.AlbumPath(db, user, album)
 	assert.NoError(t, err)
 	assert.Len(t, albumPath, 2)
 	assert.Equal(t, "Two", albumPath[0].Title)

--- a/api/graphql/models/user.go
+++ b/api/graphql/models/user.go
@@ -165,18 +165,8 @@ func (user *User) FillAlbums(db *gorm.DB) error {
 }
 
 func (user *User) OwnsAlbum(db *gorm.DB, album *Album) (bool, error) {
-
-	if err := user.FillAlbums(db); err != nil {
-		return false, err
-	}
-
-	albumIDs := make([]int, 0)
-	for _, a := range user.Albums {
-		albumIDs = append(albumIDs, a.ID)
-	}
-
 	filter := func(query *gorm.DB) *gorm.DB {
-		return query.Where("id IN (?)", albumIDs)
+		return query.Where("EXISTS (SELECT 1 FROM user_albums WHERE user_id = ? AND album_id = ? LIMIT 1)", user.ID, album.ID)
 	}
 
 	ownedParents, err := album.GetParents(db, filter)


### PR DESCRIPTION
To resolve #705.

- Remove filling albums to the user.
  - It's pretty slow if a user has a lot of albums.
- Remove checking if the user owns the album by `album_id IN ()`.
  - It's pretty slow as the `user_albums` table doesn't have a proper `user_id` index.
- Check if (user_id, album_id) exists in `user_albums` relationship table.
  - The check uses the index (user_id, album_id) as the primary key.
- Updated `album_actions_test.TestAlbumPath()` as a directory and all parent directories should be associated with the user.
  - From the root path, all sub-directories are pushed into the queue and should be associated with the user according to [`scanner_user.FindAlbumsForUser()`](https://github.com/photoview/photoview/blob/master/api/scanner/scanner_user.go#L210).
  - From my real database, a directory and all its parent directories are associated with the user.

```
sqlite> WITH recursive path_albums AS (SELECT * FROM albums anchor WHERE anchor.id = 176 UNION SELECT parent.* FROM path_albums child JOIN albums parent ON parent.id = child.parent_album_id) SELECT * FROM path_albums WHERE EXISTS (SELECT 1 FROM user_albums WHERE user_id=1 AND album_id = 176 LIMIT 1);
id|created_at|updated_at|title|parent_album_id|path|path_hash|cover_id
176|2024-05-20 15:36:35.729790324+00:00|2024-05-20 15:36:35.730176668+00:00|.......|24|/media/photos/......|e60b0bab33bbc14032a04b25e59009b8|
24|2024-05-20 15:36:24.645216255+00:00|2024-05-20 15:36:24.645989796+00:00|.......|2|/media/photos/........|459b9499d75792864768bbe494f79390|
2|2024-05-20 15:36:22.798409883+00:00|2024-05-20 15:36:22.799627995+00:00|......|1|/media/photos/......|1e3b17ed968875c070088df3f3dd81f7|
1|2024-05-20 15:36:13.829977475+00:00|2024-05-20 15:36:13.829977475+00:00|.......||/media/photos|26807d2efa623879f289dbb13cfaf931|
sqlite> SELECT * FROM user_albums WHERE user_id = 1 AND album_id IN (176, 24, 2, 1);
album_id|user_id
1|1
2|1
24|1
176|1
```