### PR TITLE
Optimize user's album filter. #705

### DIFF
--- a/api/graphql/models/user.go
+++ b/api/graphql/models/user.go
@@ -165,18 +165,8 @@ func (user *User) FillAlbums(db *gorm.DB) error {
 }
 
 func (user *User) OwnsAlbum(db *gorm.DB, album *Album) (bool, error) {
-
-	if err := user.FillAlbums(db); err != nil {
-		return false, err
-	}
-
-	albumIDs := make([]int, 0)
-	for _, a := range user.Albums {
-		albumIDs = append(albumIDs, a.ID)
-	}
-
 	filter := func(query *gorm.DB) *gorm.DB {
-		return query.Where("id IN (?)", albumIDs)
+		return query.Where("EXISTS (SELECT 1 FROM user_albums WHERE user_albums.user_id = ? AND user_albums.album_id = id LIMIT 1)", user.ID)
 	}
 
 	ownedParents, err := album.GetParents(db, filter)


### PR DESCRIPTION
To resolve #705.

- Remove filling albums to the user.
  - It's pretty slow if a user has a lot of albums.
- Remove checking if the user owns the album by `album_id IN ()`.
  - Scanning the whole table is pretty slow because the `user_albums` table doesn't have a proper `user_id` index.
- Check if (user_id, album_id) exists in `user_albums` relationship table.
  - The check uses the index (user_id, album_id) as the primary key.

```
sqlite> explain query plan WITH recursive path_albums AS (SELECT * FROM albums anchor WHERE anchor.id = 176 UNION SELECT parent.* FROM path_albums child JOIN albums parent ON parent.id = child.parent_album_id) SELECT * FROM path_albums WHERE EXISTS (SELECT 1 FROM user_albums WHERE user_albums.user_id=1 AND user_albums.album_id = id LIMIT 1);
QUERY PLAN
|--CO-ROUTINE path_albums
|  |--SETUP
|  |  `--SEARCH anchor USING INTEGER PRIMARY KEY (rowid=?)
|  `--RECURSIVE STEP
|     |--SCAN child
|     `--SEARCH parent USING INTEGER PRIMARY KEY (rowid=?)
|--SCAN path_albums
`--CORRELATED SCALAR SUBQUERY 3
   `--SEARCH user_albums USING COVERING INDEX sqlite_autoindex_user_albums_1 (album_id=? AND user_id=?)

sqlite> explain query plan WITH recursive path_albums AS (SELECT * FROM albums anchor WHERE anchor.id = 176 UNION SELECT parent.* FROM path_albums child JOIN albums parent ON parent.id = child.parent_album_id) SELECT * FROM path_albums WHERE id in (1,2,4,5,3,6,7);
QUERY PLAN
|--CO-ROUTINE path_albums
|  |--SETUP
|  |  `--SEARCH anchor USING INTEGER PRIMARY KEY (rowid=?)
|  `--RECURSIVE STEP
|     |--SCAN child
|     `--SEARCH parent USING INTEGER PRIMARY KEY (rowid=?)
`--SCAN path_albums
```