### PR TITLE
Update the healthcheck command for MariaDB container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ yarn-error.log*
 .vscode
 __debug_bin
 .idea
+.nvmrc

--- a/docker-compose example/docker-compose.example.yml
+++ b/docker-compose example/docker-compose.example.yml
@@ -125,7 +125,7 @@ services:
       - "/etc/timezone:/etc/timezone:ro"   ## use timezone from host
       - "${HOST_PHOTOVIEW_LOCATION}/database/mariadb:/var/lib/mysql" ## DO NOT REMOVE
     healthcheck:
-      test: mysqladmin ping -s -h localhost -u $$MARIADB_USER --password=$$MARIADB_PASSWORD
+      test: healthcheck.sh --connect --innodb_initialized
       interval: 1m
       timeout: 5s
       retries: 5

--- a/docker-compose example/docker-compose.minimal.example.yml
+++ b/docker-compose example/docker-compose.minimal.example.yml
@@ -75,7 +75,7 @@ services:
       - "/etc/timezone:/etc/timezone:ro"   ## use timezone from host
       - "${HOST_PHOTOVIEW_LOCATION}/database/mariadb:/var/lib/mysql" ## DO NOT REMOVE
     healthcheck:
-      test: mysqladmin ping -s -h localhost -u $$MARIADB_USER --password=$$MARIADB_PASSWORD
+      test: healthcheck.sh --connect --innodb_initialized
       interval: 1m
       timeout: 5s
       retries: 5


### PR DESCRIPTION
Fixes the #959 issue by updating the healthcheck command according to the changes in the recently updated MariaDB LTS image. Details are in the issue.