### PR TITLE
Update the minimal GO version for API module

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,14 +51,18 @@ jobs:
         working-directory: api
 
     steps:
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ^1.22
-        id: go
-
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Fetch branches
+        run: git fetch --all
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        id: go
+        with:
+          go-version-file: ${{ github.workspace }}/api/go.mod
+          cache: false
 
       - name: Cache Go dependencies
         uses: actions/cache@v2

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/photoview/photoview/api
 
-go 1.18
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.17.49


### PR DESCRIPTION
Update GO version in the `go.mod` and read it by the job to set up the testing environment for unit tests