### PR TITLE
Enhance Github Actions workflows

### DIFF
--- a/.dockleignore
+++ b/.dockleignore
@@ -1,0 +1,5 @@
+# Allow the `latest` tag
+DKL-DI-0006
+
+# Don't care about signatures
+CIS-DI-0005

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,29 +30,31 @@ jobs:
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
           echo "tag=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_OUTPUT
 
+      - name: Prepare matrix
+        id: matrix
+        run: |
+          if [[ -n "${{ steps.gettag.outputs.tag }}" ]]; then
+            echo "matrix=$(jq -cn --arg tag '${{ steps.gettag.outputs.tag }}' '{ref: ["refs/heads/master", $tag]}')" >> $GITHUB_OUTPUT
+          else
+            echo "matrix=$(jq -cn --arg ref '${{ github.ref }}' '{ref: [$ref]}' )" >> $GITHUB_OUTPUT
+          fi
+
     outputs:
-      latest_tag: ${{ steps.gettag.outputs.tag }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
 
   build:
     name: Build Docker Image
     runs-on: ubuntu-latest
     needs: prepare
     strategy:
-      matrix:
-        include:
-          - ref: 'refs/heads/master'
-          - ref: '${{ needs.prepare.outputs.latest_tag }}'
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
 
     steps:
-      - name: Checkout (if scheduled run) for ${{ matrix.ref }}
-        if: github.event_name == 'schedule'
+      - name: Checkout of ${{ matrix.ref }}
         uses: actions/checkout@v4
         with:
           ref: ${{ matrix.ref }}
-
-      - name: Checkout (if triggered by other event type)
-        if: github.event_name != 'schedule'
-        uses: actions/checkout@v4
 
       - name: Fetch branches
         run: git fetch --all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,39 +16,33 @@ env:
 jobs:
   build:
     name: Build Docker Image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        id: cache
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ secrets.CACHE_KEY }}-${{ matrix.target_platform }}-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-${{ secrets.CACHE_KEY }}-${{ matrix.target_platform }}-
+      - name: Fetch branches
+        run: git fetch --all
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
         with:
-          platforms: ${{ matrix.target_platform }}
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker Login
         if: success() && github.event_name != 'pull_request' && github.repository == 'photoview/photoview'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
           images: ${{ env.DOCKER_IMAGE }}
@@ -63,10 +57,48 @@ jobs:
             type=sha
 
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
+          sbom: true
+          provenance: mode=max
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          pull: true
           push: ${{ github.event_name != 'pull_request' && github.repository == 'photoview/photoview' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  dockle:
+    name: Dockle Container Analysis
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.repository == 'photoview/photoview' && github.event_name != 'pull_request'
+    steps:
+       # Makes sure your .dockleignore file is available to the next step
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
+
+      - name: Run Dockle
+        uses: erzz/dockle-action@v1
+        with:
+          image: ${{ env.DOCKER_IMAGE }}:master
+          report-name: dockle-results
+          report-format: sarif
+          failure-threshold: fatal
+          exit-code: 1
+          timeout: 5m
+
+      - name: Upload SARIF file
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: dockle-results.sarif

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,42 @@ env:
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
 jobs:
+  prepare:
+    name: Provide a ref for the latest tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get latest tag (if schedule run)
+        id: gettag
+        if: github.event_name == 'schedule'
+        run: |
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          echo "tag=$(git describe --tags `git rev-list --tags --max-count=1`)" >> $GITHUB_OUTPUT
+
+    outputs:
+      latest_tag: ${{ steps.gettag.outputs.tag }}
+
   build:
     name: Build Docker Image
     runs-on: ubuntu-latest
+    needs: prepare
+    strategy:
+      matrix:
+        include:
+          - ref: 'refs/heads/master'
+          - ref: '${{ needs.prepare.outputs.latest_tag }}'
 
     steps:
-      - name: Checkout
+      - name: Checkout (if scheduled run) for ${{ matrix.ref }}
+        if: github.event_name == 'schedule'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.ref }}
+
+      - name: Checkout (if triggered by other event type)
+        if: github.event_name != 'schedule'
         uses: actions/checkout@v4
 
       - name: Fetch branches
@@ -69,7 +99,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' && github.repository == 'photoview/photoview' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.annotations }}
+          annotations: ${{ steps.docker_meta.outputs.annotations }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -79,7 +109,7 @@ jobs:
     needs: build
     if: github.repository == 'photoview/photoview' && github.event_name != 'pull_request'
     steps:
-       # Makes sure your .dockleignore file is available to the next step
+      # Makes sure your .dockleignore file is available to the next step
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
     branches: [master]
     tags:
       - v*
+  schedule:
+    - cron: '0 1 * * 4'
 
 env:
   DOCKER_USERNAME: viktorstrate

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,8 +28,6 @@ permissions:
 jobs:
   create-matrix:
     runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.set-matrix.outputs.languages }}
     steps:
       - name: Get languages from repo
         id: set-matrix
@@ -37,6 +35,8 @@ jobs:
         with:
           access-token: ${{ github.token }}
           endpoint: ${{ github.event.repository.languages_url }}
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.languages }}
 
   analyze:
     name: Analyze
@@ -153,7 +153,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             });
-            
+
             const botComment = comments.data.find(comment => comment.user.login === 'github-actions[bot]' && comment.body.includes('Anchore'));
 
             output += '#### Anchore Grype scan results:\n';
@@ -219,19 +219,19 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             });
-            
+
             const botComment = comments.data.find(
               comment => comment.user.login === 'github-actions[bot]'
               && comment.body.includes('Hadolint (photoview) issues:')
             );
 
             if (hadolintResults) {
-  
+
               output += '#### Hadolint (photoview) issues:\n';
               output += 'Hadolint detected issues for the `photoview` image during execution.\n';
               output += '\n```\n' + hadolintResults + '\n```\n';
               output += '\nFind more info about detected issues and recommendations for fixes in the [Rules table](https://github.com/hadolint/hadolint?tab=readme-ov-file#rules).';
-  
+
               if (botComment) {
                 await github.rest.issues.updateComment({
                   comment_id: botComment.id,
@@ -247,7 +247,7 @@ jobs:
                   body: output
                 });
               }
-            
+
             } else {
 
               if (botComment) {
@@ -258,6 +258,7 @@ jobs:
                 });
               }
             }
+
       - name: Generate report
         uses: hadolint/hadolint-action@v3.1.0
         if: always()

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,10 +10,23 @@ on:
     - cron: '0 1 * * 4'
 
 jobs:
+  create-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.languages }}
+    steps:
+      - name: Get languages from repo
+        id: set-matrix
+        uses: advanced-security/set-codeql-language-matrix@v1
+        with:
+          access-token: ${{ github.token }}
+          endpoint: ${{ github.event.repository.languages_url }}
+
   analyze:
     name: Analyze
-    if: github.repository == 'photoview/photoview'
-    runs-on: ubuntu-20.04
+    needs: create-matrix
+    if: ${{ needs.create-matrix.outputs.matrix != '[]' }} && github.repository == 'photoview/photoview'
+    runs-on: ubuntu-latest
 
     # strategy:
     #   fail-fast: false
@@ -24,17 +37,223 @@ jobs:
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{ fromJSON(needs.create-matrix.outputs.matrix) }}
+
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v1
+        uses: github/codeql-action/init@v3
         with:
-          languages: go, javascript
+          languages: ${{ matrix.language }}
           # Run further tests
           queries: security-extended, security-and-quality
 
+      # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
+      - name: Auto-build
+        uses: github/codeql-action/autobuild@v3
+
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v1
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"
+
+  anchore:
+    name: Anchore scan code dependencies
+    if: github.repository == 'photoview/photoview'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate report
+        id: scan
+        uses: anchore/scan-action@v3
+        with:
+          path: "."
+          fail-build: false
+          add-cpes-if-none: true
+
+      - name: Upload report
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: ${{ steps.scan.outputs.sarif }}
+
+      - name: Scan PR source code
+        id: scan-fixed
+        uses: anchore/scan-action@v3
+        if: always() && github.event_name == 'pull_request'
+        with:
+          path: "."
+          fail-build: false
+          add-cpes-if-none: true
+          output-format: json
+          severity-cutoff: high
+          only-fixed: true
+
+      - name: Prepare JSON
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          jq '{
+            "|": .matches | map({
+              "language": .artifact.language,
+              "id": .vulnerability.id,
+              "severity": .vulnerability.severity,
+              "name": .artifact.name,
+              "version": .artifact.version,
+              "fix-versions": .vulnerability.fix.versions[0],
+              "path": .artifact.locations[0].path,
+              "description": .vulnerability.description
+            })
+          }' ${{ steps.scan-fixed.outputs.json }} > vulns.json
+          cat vulns.json | jq
+
+      - name: JSON to Table
+        uses: Teebra/JSON-to-HTML-table@v2.0.0
+        if: always() && github.event_name == 'pull_request'
+        with:
+          json-file: vulns.json
+
+      - name: Update Pull Request
+        uses: actions/github-script@v7
+        if: always() && github.event_name == 'pull_request'
+        with:
+          # To fix failed job in Dependabot PRs I need the static token to be set in secrets (both Actions and Dependabot)
+          # github-token: ${{ secrets.COMMENT_TOKEN }}
+          script: |
+            const fs = require('fs');
+            let scanResults = fs.readFileSync('output.html', 'utf8');
+            let output = '';
+
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            
+            const botComment = comments.data.find(comment => comment.user.login === 'github-actions[bot]' && comment.body.includes('Anchore'));
+
+            output += '#### Anchore Grype scan results:\n';
+            output += 'Anchore Grype detected vulnerabilities in project dependencies, for which fixed versions are available.\n';
+            output += 'Please find more details in the "Checks" tab of this PR > "Code scanning results" > "Grype".\n';
+
+            if (scanResults) {
+              output += '\n' + scanResults + '\n';
+
+              if (botComment) {
+                await github.rest.issues.updateComment({
+                  comment_id: botComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: output
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: output
+                });
+              }
+            } else {
+              if (botComment) {
+                await github.rest.issues.deleteComment({
+                  comment_id: botComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo
+                });
+              }
+            }
+
+  hadolint:
+    name: Hadolint Dockerfile
+    if: github.repository == 'photoview/photoview'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lint Dockerfile
+        id: hadolint
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          config: ${{ github.workspace }}/.hadolint.yaml
+          format: tty
+          failure-threshold: error
+
+      - name: Update Pull Request
+        uses: actions/github-script@v7
+        if: always() && github.event_name == 'pull_request'
+        with:
+          script: |
+            let hadolintResults = process.env.HADOLINT_RESULTS;
+            let output = '';
+
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            
+            const botComment = comments.data.find(
+              comment => comment.user.login === 'github-actions[bot]'
+              && comment.body.includes('Hadolint (photoview) issues:')
+            );
+
+            if (hadolintResults) {
+  
+              output += '#### Hadolint (photoview) issues:\n';
+              output += 'Hadolint detected issues for the `photoview` image during execution.\n';
+              output += '\n```\n' + hadolintResults + '\n```\n';
+              output += '\nFind more info about detected issues and recommendations for fixes in the [Rules table](https://github.com/hadolint/hadolint?tab=readme-ov-file#rules).';
+  
+              if (botComment) {
+                await github.rest.issues.updateComment({
+                  comment_id: botComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: output
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: output
+                });
+              }
+            
+            } else {
+
+              if (botComment) {
+                await github.rest.issues.deleteComment({
+                  comment_id: botComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo
+                });
+              }
+            }
+      - name: Generate report
+        uses: hadolint/hadolint-action@v3.1.0
+        if: always()
+        with:
+          dockerfile: Dockerfile
+          config: ${{ github.workspace }}/.hadolint.yaml
+          output-file: hadolint.sarif
+          format: sarif
+          failure-threshold: error
+
+      - name: Upload report
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: hadolint.sarif

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,22 @@ on:
   schedule:
     - cron: '0 1 * * 4'
 
+permissions:
+  actions: read
+  attestations: write
+  checks: read
+  contents: write
+  deployments: read
+  discussions: none
+  id-token: write
+  issues: none
+  packages: none
+  pages: none
+  pull-requests: write
+  repository-projects: none
+  security-events: write
+  statuses: write
+
 jobs:
   create-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test-api:
     name: Test API
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -18,31 +18,32 @@ jobs:
 
     services:
       mariadb:
-        image: mariadb:10.5
+        image: mariadb:lts
         env:
           MYSQL_DATABASE: photoview_test
           MYSQL_USER: photoview
           MYSQL_PASSWORD: photosecret
           MYSQL_RANDOM_ROOT_PASSWORD: yes
+        # https://github.com/MariaDB/mariadb-docker/issues/497
         options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
+          --health-cmd="mariadb-admin ping"
+          --health-interval=20s
           --health-timeout=5s
-          --health-retries=5
+          --health-retries=10
         ports:
           - 3306:3306
 
       postgres:
-        image: postgres:13.2
+        image: postgres:16-alpine
         env:
           POSTGRES_USER: photoview
           POSTGRES_PASSWORD: photosecret
           POSTGRES_DB: photoview_test
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 20s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 10
         ports:
           - 5432:5432
 
@@ -65,7 +66,7 @@ jobs:
           cache: false
 
       - name: Cache Go dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -107,12 +108,14 @@ jobs:
           cp ../.github/sqlite.testing.env testing.env
 
       - name: Test
-        run: go test ./... -v -database -filesystem -p 1 -coverprofile=coverage.txt -covermode=atomic
+        run: go test ./... -v -database -filesystem -p 1 -coverprofile=coverage.txt -covermode=atomic -json > test-report.json
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
+        if: always()
         with:
           flags: api
+          # token: ${{ secrets.CODECOV_TKN }}
 
   test-ui:
     name: Test UI
@@ -124,31 +127,45 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18]
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Cache NPM dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+      - name: Fetch branches
+        run: git fetch --all
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+          cache-dependency-path: ui/package-lock.json
 
       - name: Install dependencies
         run: npm clean-install
+
+      - name: NPM audit
+        uses: oke-py/npm-audit-action@v2
+        with:
+          audit_level: none
+          create_issues: false
+          github_token: ${{ github.token }}
+          dedupe_issues: true
+          production_flag: true
+          working_directory: ui
 
       - name: Test
         run: npm run test:ci
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           flags: ui
+          # token: ${{ secrets.CODECOV_TKN }}
+
+      - name: Run ESLint
+        run: |
+          npm clean-install --include dev
+          npm run lint:ci || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,10 +125,6 @@ jobs:
       run:
         working-directory: ui
 
-    strategy:
-      matrix:
-        node-version: [18]
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -136,10 +132,10 @@ jobs:
       - name: Fetch branches
         run: git fetch --all
 
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 18
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18
           cache: 'npm'
           cache-dependency-path: ui/package-lock.json
 

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,4 @@
+ignored:
+  - DL3008 # Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
+  - DL3015 # Avoid additional packages by specifying `--no-install-recommends`.
+  - SC1091 # Not following: File not included in mock.

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,7 +13,7 @@
     "build": "vite build",
     "lint": "eslint ./src --max-warnings 0 --config .eslintrc.js",
     "test": "vitest",
-    "test:ci": "CI=true vitest --reporter verbose --run --coverage",
+    "test:ci": "CI=true vitest --reporter=junit --reporter=verbose --run --coverage",
     "genSchemaTypes": "apollo client:codegen --target=typescript --globalTypesFile=src/__generated__/globalTypes.ts --passthroughCustomScalars && prettier --write */**/__generated__/*.ts",
     "extractTranslations": "i18next -c i18next-parser.config.js",
     "prepare": "(cd .. && ./ui/node_modules/.bin/husky install)"

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -18,8 +18,12 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './testing/setupTests.ts',
+    reporters: ['verbose', 'junit'],
+    outputFile: {
+      junit: './junit-report.xml',
+    },
     coverage: {
-      reporter: ['text', 'json', 'html'],
+      reporter: ['text', 'lcov', 'json', 'html'],
     },
   },
 })


### PR DESCRIPTION
Migrate part of workflow from my forked repo to the main repo with updating versions of used actions:
- Updated versions of used actions, DB images, and the runner VM to the latest ones
- Added Dockle image scanner job (runs in `master` because needs to pull the image, which is pushed only for this branch) with reporting to the Security tab of the repo
- Optimized existing jobs with better steps configuration
- Added Anchore Grype dependency scanner job with reporting to the Security tab of the repo (all issues) and to the comment in the PR's discussion (only dependencies with fixed versions released)
- Added Hadolint linter of Dockerfile with reporting to the Security tab of the repo and to the comment in the PR's discussion
- Added NPM Audit step to UI tests with reporting to the Github Actions step output
- Added ESLint step to UI tests with reporting to the Github Actions step output
- Configured Unit tests to output results also in the standard JUnit format with coverage reports in Lcov (for UI tests) for future integrations