### PR TITLE
fix: break thumbnails in sidebar to multiple lines

### DIFF
--- a/ui/src/components/sidebar/MediaSidebar/MediaSidebarPeople.tsx
+++ b/ui/src/components/sidebar/MediaSidebar/MediaSidebarPeople.tsx
@@ -208,7 +208,7 @@ const MediaSidebarPeople = ({ media }: MediaSidebarFacesProps) => {
         className="overflow-x-auto mb-[-200px]"
         style={{ scrollbarWidth: 'none' }}
       >
-        <ul className="flex gap-4 mx-4">{faceElms}</ul>
+        <ul className="flex flex-wrap justify-evenly gap-4 mx-4">{faceElms}</ul>
         <div className="h-[200px]"></div>
       </div>
     </SidebarSection>


### PR DESCRIPTION
In the sidebar if when I have more than 3 thumbnails, only the first 3
is visible. That makes very hard to view or edit the faces that are
recognized on the photo.

The fix is to break the thumbnails to new line when needed by adding the
flex-wrap class to the container ul element.

## old behavior
![image](https://github.com/photoview/photoview/assets/38329/6e2e4f22-37bf-4199-8574-469ec827cd8a)

## new behavior
![image](https://github.com/photoview/photoview/assets/38329/925bfc0a-21c2-4601-9eb2-2a31742f9d60)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the People section in the Media sidebar to wrap items across multiple lines and evenly distribute them within each row. This improves responsiveness, prevents overflow on narrower viewports, and provides more consistent spacing and readability across screen sizes. No functional behavior or data handling changed; the update strictly refines layout and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->