### PR TITLE
order root albums by path on settings page

### DIFF
--- a/api/graphql/resolvers/user.go
+++ b/api/graphql/resolvers/user.go
@@ -56,7 +56,7 @@ func (r *userResolver) RootAlbums(ctx context.Context, user *models.User) (album
 			db.Table("user_albums").
 				Select("albums.id").
 				Joins("JOIN albums ON albums.id = user_albums.album_id AND user_albums.user_id = ?", user.ID),
-		).Or("albums.parent_album_id IS NULL").
+		).Or("albums.parent_album_id IS NULL").Order("path ASC").
 		Association("Albums").Find(&albums)
 
 	return

--- a/api/scanner/scanner_user.go
+++ b/api/scanner/scanner_user.go
@@ -55,7 +55,11 @@ func FindAlbumsForUser(db *gorm.DB, user *models.User, album_cache *scanner_cach
 	}
 
 	var userRootAlbums []*models.Album
-	if err := db.Where("id IN (?)", userAlbumIDs).Where("parent_album_id IS NULL OR parent_album_id NOT IN (?)", userAlbumIDs).Find(&userRootAlbums).Error; err != nil {
+	if err := db.
+		Where("id IN (?)", userAlbumIDs).
+		Where("parent_album_id IS NULL OR parent_album_id NOT IN (?)", userAlbumIDs).
+		Order("path ASC").
+		Find(&userRootAlbums).Error; err != nil {
 		return nil, []error{err}
 	}
 


### PR DESCRIPTION
Once you have more than a few paths assigned to a user, it becomes quite hard to oversee the list.

Personally, I would add my albums to Photoview one by one, so I can manage the processing better. For example, I can review and fix the face recognition for one new album at a time, and I don't need to deal with too much data.
Since I started to add the albums in a random order, it's relatively hard to find which album is added and which is not.

An easy fix is to order the photo paths by their name.

- Extended the query of the rootAlbums to order them by path
