### PR TITLE
Fix exif migrations test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ cache/
 /api/media_cache/
 /photos_path
 photoview.db
-photoview.db-journal
+photoview.db-*
 
 .env
 testing.env

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ node_modules/
 # testing
 /ui/coverage
 /api/coverage.txt
+/dev
 
 # building
 .cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ ENV COMMIT_SHA=${COMMIT_SHA:-}
 ENV REACT_APP_BUILD_COMMIT_SHA=${COMMIT_SHA:-}
 
 # Download dependencies
-COPY ui /app
-WORKDIR /app
+COPY . /app
+WORKDIR /app/ui
 RUN npm ci --omit=dev --ignore-scripts \
   # Build frontend
   && npm run build -- --base=$UI_PUBLIC_URL
@@ -37,18 +37,17 @@ ARG TARGETPLATFORM
 # See for details: https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-COPY scripts /tmp/scripts
-COPY api /app
-WORKDIR /app
+COPY . /app
+WORKDIR /app/api
 
 ENV GOPATH="/go"
 ENV PATH="${GOPATH}/bin:${PATH}"
 ENV CGO_ENABLED=1
 
 # Download dependencies
-RUN chmod +x /tmp/scripts/*.sh \
-  && /tmp/scripts/install_build_dependencies.sh \
-  && source /tmp/scripts/set_go_env.sh \
+RUN chmod +x /app/scripts/*.sh \
+  && /app/scripts/install_build_dependencies.sh \
+  && source /app/scripts/set_go_env.sh \
   && go env \
   && go mod download \
   # Patch go-face
@@ -90,8 +89,8 @@ RUN groupadd -g 999 photoview \
 
 WORKDIR /home/photoview
 COPY api/data /app/data
-COPY --from=ui /app/dist /app/ui
-COPY --from=api /app/photoview /app/photoview
+COPY --from=ui /app/ui/dist /app/ui
+COPY --from=api /app/api/photoview /app/photoview
 
 ENV PHOTOVIEW_LISTEN_IP=127.0.0.1
 ENV PHOTOVIEW_LISTEN_PORT=80

--- a/api/database/migrations/exif_invalid_gps_test.go
+++ b/api/database/migrations/exif_invalid_gps_test.go
@@ -1,10 +1,7 @@
 package migrations_test
 
 import (
-	"bufio"
 	"math"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,23 +12,6 @@ import (
 )
 
 func TestExifMigration(t *testing.T) {
-	envFile, err := os.Open("/home/runner/work/photoview/photoview/api/testing.env")
-	if err != nil {
-		t.Fatalf("Failed to open environment file: %v", err)
-	}
-	defer envFile.Close()
-
-	scanner := bufio.NewScanner(envFile)
-	for scanner.Scan() {
-		line := scanner.Text()
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) != 2 {
-			t.Fatalf("Invalid line in environment file: %s", line)
-		}
-		key, value := parts[0], strings.Trim(parts[1], "'")
-		os.Setenv(key, value)
-	}
-
 	db := test_utils.DatabaseTest(t)
 	defer db.Exec("DELETE FROM media_exif") // Clean up after test
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,47 @@
+name: photoview
+
+services:
+  mariadb:
+    image: mariadb:lts
+    environment:
+      MYSQL_DATABASE: photoview_test
+      MYSQL_USER: photoview
+      MYSQL_PASSWORD: photosecret
+      MYSQL_RANDOM_ROOT_PASSWORD: yes
+    healthcheck:
+      test:
+      - CMD
+      - mariadb-admin
+      - --user=photoview
+      - --password=photosecret
+      - ping
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ports:
+      - 3306:3306
+
+  postgres:
+    image: postgres:latest
+    environment:
+      POSTGRES_USER: photoview
+      POSTGRES_PASSWORD: photosecret
+      POSTGRES_DB: photoview_test
+    healthcheck:
+      test:
+      - CMD
+      - pg_isready
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ports:
+      - 5432:5432
+
+  api:
+    image: photoview/photoview-api
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: api
+    volumes:
+    - .:/app:rw

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,5 +43,19 @@ services:
       context: .
       dockerfile: Dockerfile
       target: api
+    command: 
+    - /bin/bash
+    - -c
+    - "source /app/scripts/set_go_env.sh; go run ."
+    volumes:
+    - .:/app:rw
+
+  ui:
+    image: photoview/photoview-ui
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: ui
+    command: "npm ci --omit=dev --ignore-scripts && npm run build -- --base=$UI_PUBLIC_URL"
     volumes:
     - .:/app:rw

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,12 @@
 name: photoview
 
+volumes:
+  mariadb:
+  postgres:
+
 services:
   mariadb:
-    image: mariadb:lts
+    image: mariadb:11.4
     environment:
       MYSQL_DATABASE: photoview_test
       MYSQL_USER: photoview
@@ -18,15 +22,17 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    volumes:
+    - mariadb:/var/lib/mysql:rw
     ports:
-      - 3306:3306
+    - 3306:3306
 
   postgres:
-    image: postgres:latest
+    image: postgres:16.3
     environment:
+      POSTGRES_DB: photoview_test
       POSTGRES_USER: photoview
       POSTGRES_PASSWORD: photosecret
-      POSTGRES_DB: photoview_test
     healthcheck:
       test:
       - CMD
@@ -34,8 +40,10 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    volumes:
+    - postgres:/var/lib/postgresql/data:rw
     ports:
-      - 5432:5432
+    - 5432:5432
 
   api:
     image: photoview/photoview-api
@@ -43,10 +51,14 @@ services:
       context: .
       dockerfile: Dockerfile
       target: api
+    env_file: scripts/env.api
     command: 
     - /bin/bash
     - -c
-    - "source /app/scripts/set_go_env.sh; go run ."
+    - |
+      git config --global --add safe.directory /app
+      source /app/scripts/set_go_env.sh
+      go run .
     volumes:
     - .:/app:rw
 
@@ -56,6 +68,11 @@ services:
       context: .
       dockerfile: Dockerfile
       target: ui
-    command: "npm ci --omit=dev --ignore-scripts && npm run build -- --base=$UI_PUBLIC_URL"
+    command:
+    - /bin/bash
+    - -c
+    - |
+      npm ci --omit=dev --ignore-scripts
+      npm run build -- --base=$UI_PUBLIC_URL
     volumes:
     - .:/app:rw

--- a/scripts/env.api
+++ b/scripts/env.api
@@ -1,0 +1,28 @@
+# Copy this file to .env
+
+PHOTOVIEW_DATABASE_DRIVER=sqlite
+
+PHOTOVIEW_MYSQL_URL='photoview:photosecret@tcp(mariadb)/photoview_test'
+PHOTOVIEW_POSTGRES_URL='postgres://photoview:photosecret@postgres:5432/photoview_test'
+PHOTOVIEW_SQLITE_PATH=/app/photoview.db
+
+PHOTOVIEW_LISTEN_IP=localhost
+PHOTOVIEW_LISTEN_PORT=4001
+
+# The url from which the server can be accessed publicly
+PHOTOVIEW_API_ENDPOINT=
+PHOTOVIEW_UI_ENDPOINT=
+
+# Path where media should be cached, defaults to ./media_cache
+# PHOTOVIEW_MEDIA_CACHE=./media_cache
+
+# Set to 1 for the server to also serve the built static ui files
+PHOTOVIEW_SERVE_UI=0
+
+# Enter a valid mapbox token, to enable maps feature
+# A token can be created for free at https://mapbox.com
+#MAPBOX_TOKEN=<insert mapbox token here>
+
+# Set to 1 to set server in development mode, this enables graphql playground
+# Remove this if running in production
+PHOTOVIEW_DEVELOPMENT_MODE=1

--- a/scripts/env.ui
+++ b/scripts/env.ui
@@ -1,0 +1,28 @@
+# Copy this file to .env
+
+PHOTOVIEW_DATABASE_DRIVER=sqlite
+
+PHOTOVIEW_MYSQL_URL='photoview:photosecret@tcp(mariadb)/photoview_test'
+PHOTOVIEW_POSTGRES_URL='postgres://photoview:photosecret@postgres:5432/photoview_test'
+PHOTOVIEW_SQLITE_PATH=/app/photoview.db
+
+PHOTOVIEW_LISTEN_IP=localhost
+PHOTOVIEW_LISTEN_PORT=4001
+
+# The url from which the server can be accessed publicly
+PHOTOVIEW_API_ENDPOINT=
+PHOTOVIEW_UI_ENDPOINT=http://localhost:1234/
+
+# Path where media should be cached, defaults to ./media_cache
+# PHOTOVIEW_MEDIA_CACHE=./media_cache
+
+# Set to 1 for the server to also serve the built static ui files
+PHOTOVIEW_SERVE_UI=0
+
+# Enter a valid mapbox token, to enable maps feature
+# A token can be created for free at https://mapbox.com
+#MAPBOX_TOKEN=<insert mapbox token here>
+
+# Set to 1 to set server in development mode, this enables graphql playground
+# Remove this if running in production
+PHOTOVIEW_DEVELOPMENT_MODE=1

--- a/scripts/set_go_env.sh
+++ b/scripts/set_go_env.sh
@@ -7,11 +7,12 @@
 : ${TARGETOS=}
 : ${TARGETARCH=}
 : ${TARGETVARIANT=}
-: ${CGO_ENABLED=}
-: ${GOARCH=}
-: ${GOOS=}
-: ${GOARM=}
-: ${GOBIN=}
+
+CGO_ENABLED=`go env CGO_ENABLED`
+GOARCH=`go env GOARCH`
+GOOS=`go env GOOS`
+GOARM=`go env GOARM`
+GOBIN=`go env GOBIN`
 
 set -eu
 


### PR DESCRIPTION
`database.ConfigureDatabase()` reads env variables to setup db. You don't need to load env from the test file.

Also, that env file doesn't exist in the repo. A developer can't pass the test locally.

See the test log, running from my scripts branch:

```
root@a6374b07390a:/app/api# PHOTOVIEW_DATABASE_DRIVER=mysql go test ./database/migrations/... -count=1 -v --database
=== RUN   TestExifMigration
2024/06/30 19:21:44 Utilizing mysql database driver based on environment variables
--- PASS: TestExifMigration (0.66s)
PASS
ok  	github.com/photoview/photoview/api/database/migrations	0.782s
root@a6374b07390a:/app/api# go test ./database/migrations/... -count=1 -v --database
=== RUN   TestExifMigration
2024/06/30 19:21:57 Utilizing sqlite database driver based on environment variables
--- PASS: TestExifMigration (0.28s)
PASS
ok  	github.com/photoview/photoview/api/database/migrations	0.404s
```