### PR TITLE
Remove loading env from tests.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: ["*"]
+    branches: [master]
   pull_request:
     branches: [master]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: ["*"]
   pull_request:
     branches: [master]
 

--- a/api/database/migrations/exif_invalid_gps_test.go
+++ b/api/database/migrations/exif_invalid_gps_test.go
@@ -1,10 +1,7 @@
 package migrations_test
 
 import (
-	"bufio"
 	"math"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,23 +12,6 @@ import (
 )
 
 func TestExifMigration(t *testing.T) {
-	envFile, err := os.Open("/home/runner/work/photoview/photoview/api/testing.env")
-	if err != nil {
-		t.Fatalf("Failed to open environment file: %v", err)
-	}
-	defer envFile.Close()
-
-	scanner := bufio.NewScanner(envFile)
-	for scanner.Scan() {
-		line := scanner.Text()
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) != 2 {
-			t.Fatalf("Invalid line in environment file: %s", line)
-		}
-		key, value := parts[0], strings.Trim(parts[1], "'")
-		os.Setenv(key, value)
-	}
-
 	db := test_utils.DatabaseTest(t)
 	defer db.Exec("DELETE FROM media_exif") // Clean up after test
 

--- a/api/database/migrations/migrations_test.go
+++ b/api/database/migrations/migrations_test.go
@@ -1,0 +1,12 @@
+package migrations_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/photoview/photoview/api/test_utils"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(test_utils.IntegrationTestRun(m))
+}


### PR DESCRIPTION
The env file doesn't exist in local test env and the local test won't succeed with it. I run tests with `TestMain()` as how other tests do, like `api/graphql/models/models_test.go` and load env with flags.