### PR TITLE
add option to download all pictures as zip from share

### DIFF
--- a/ui/src/components/album/AlbumTitle.test.tsx
+++ b/ui/src/components/album/AlbumTitle.test.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
-import { render, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import { render, waitFor, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MockedProvider } from '@apollo/client/testing'
 import AlbumTitle, { ALBUM_PATH_QUERY } from './AlbumTitle'
 import { MemoryRouter } from 'react-router'
+import { SidebarContext } from '../sidebar/Sidebar'
 
 import * as authentication from '../../helpers/authentication'
 
@@ -94,10 +97,22 @@ describe('AlbumTitle', () => {
       },
     }
 
+    const updateSidebarMock = vi.fn()
+    const setPinnedMock = vi.fn()
+
+    const sidebarContextProvider = {
+      updateSidebar: updateSidebarMock,
+      setPinned: setPinnedMock,
+      content: <div>Hello, world!</div>,
+      pinned: false,
+    }
+
     render(
       <MockedProvider mocks={[subfolderAlbumMock]}>
         <MemoryRouter>
-          <AlbumTitle album={album} disableLink={true} />
+          <SidebarContext.Provider value={sidebarContextProvider}>
+            <AlbumTitle album={album} disableLink={true} />
+          </SidebarContext.Provider>
         </MemoryRouter>
       </MockedProvider>
     )
@@ -119,5 +134,9 @@ describe('AlbumTitle', () => {
       const breadcrumb = document.querySelector('nav > ol > li > a')
       expect(breadcrumb?.textContent).toMatch(/demoAlbum/)
     })
+
+    await userEvent.click(screen.getByTitle('Album options'))
+
+    expect(updateSidebarMock).toHaveBeenCalled()
   })
 })

--- a/ui/src/components/album/AlbumTitle.test.tsx
+++ b/ui/src/components/album/AlbumTitle.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import AlbumTitle, { ALBUM_PATH_QUERY } from './AlbumTitle'
+import { MemoryRouter } from 'react-router'
+
+import * as authentication from '../../helpers/authentication'
+
+vi.mock('../../helpers/authentication.ts')
+
+const authToken = vi.mocked(authentication.authToken)
+
+const album = {
+  id: '30',
+  title: 'testAlbum',
+}
+
+describe('AlbumTitle', () => {
+  test('render albumTitle - no album given, unauthorized', () => {
+    authToken.mockImplementation(() => null)
+    const { queryByText } = render(
+      <MockedProvider mocks={[]}>
+        <AlbumTitle disableLink />
+      </MockedProvider>
+    )
+    expect(queryByText('Album options')).not.toBeInTheDocument()
+  })
+
+  test('render albumTitle - album given, disableLink=true, unauthorized', async () => {
+    authToken.mockImplementation(() => null)
+
+    render(
+      <MockedProvider mocks={[]}>
+        <MemoryRouter>
+          <AlbumTitle album={album} disableLink={true} />
+        </MemoryRouter>
+      </MockedProvider>
+    )
+    await waitFor(() => {
+      // check if the string "Album options" is rendered / the settings button is visible
+      const button = document.querySelector('button')
+      const title = button?.getAttribute('title')
+      expect(title).toBe('Album options')
+
+      // check if the name of the album is in span
+      const span = document.querySelector('h1 > span')
+      expect(span?.textContent).toMatch(/testAlbum/)
+
+      // check if the name of the album is not in a link
+      const linkSpan = document.querySelector('h1 > link > span')
+      expect(linkSpan).toBeNull()
+    })
+  })
+
+  test('render albumTitle - album given, disableLink=false, unauthorized', async () => {
+    authToken.mockImplementation(() => null)
+
+    render(
+      <MockedProvider mocks={[]}>
+        <MemoryRouter>
+          <AlbumTitle album={album} disableLink={false} />
+        </MemoryRouter>
+      </MockedProvider>
+    )
+    await waitFor(() => {
+      // check if the string "Album options" is rendered / the settings button is visible
+      const button = document.querySelector('button')
+      const title = button?.getAttribute('title')
+      expect(title).toBe('Album options')
+
+      // check if the name of the album is in span
+      const span = document.querySelector('h1 > span')
+      expect(span).toBeNull()
+
+      // check if the name of the album is in a link
+      const linkSpan = document.querySelector('h1 > a > span')
+      expect(linkSpan?.textContent).toMatch(/testAlbum/)
+    })
+  })
+
+  test('render albumTitle - album given, disableLink=true, authorized, breadcrumb', async () => {
+    authToken.mockImplementation(() => 'token-here')
+    const subfolderAlbumMock = {
+      request: { query: ALBUM_PATH_QUERY, variables: { id: '30' } },
+      result: {
+        data: {
+          album: {
+            id: '30',
+            title: 'testAlbum',
+            path: [{ id: '2', title: 'demoAlbum', __typename: 'Album' }],
+            __typename: 'Album',
+          },
+        },
+      },
+    }
+
+    render(
+      <MockedProvider mocks={[subfolderAlbumMock]}>
+        <MemoryRouter>
+          <AlbumTitle album={album} disableLink={true} />
+        </MemoryRouter>
+      </MockedProvider>
+    )
+    await waitFor(() => {
+      // check if the string "Album options" is rendered / the settings button is visible
+      const button = document.querySelector('button')
+      const title = button?.getAttribute('title')
+      expect(title).toBe('Album options')
+
+      // check if the name of the album is in span
+      const span = document.querySelector('h1 > span')
+      expect(span?.textContent).toMatch(/testAlbum/)
+
+      // check if the name of the album is not in a link
+      const linkSpan = document.querySelector('h1 > link > span')
+      expect(linkSpan).toBeNull()
+
+      // check if the breadcrumb is rendered
+      const breadcrumb = document.querySelector('nav > ol > li > a')
+      expect(breadcrumb?.textContent).toMatch(/demoAlbum/)
+    })
+  })
+})

--- a/ui/src/components/album/AlbumTitle.tsx
+++ b/ui/src/components/album/AlbumTitle.tsx
@@ -103,18 +103,18 @@ const AlbumTitle = ({ album, disableLink = false }: AlbumTitleProps) => {
         </nav>
         <h1 className="text-2xl truncate min-w-0">{title}</h1>
       </div>
-      {authToken() && (
-        <button
-          title="Album options"
-          aria-label="Album options"
-          className={tailwindClassNames(buttonStyles({}), 'px-2 py-2 ml-2')}
-          onClick={() => {
-            updateSidebar(<AlbumSidebar albumId={album.id} />)
-          }}
-        >
-          <GearIcon />
-        </button>
-      )}
+      <button
+        title="Album options"
+        aria-label="Album options"
+        className={tailwindClassNames(buttonStyles({}), 'px-2 py-2 ml-2')}
+        onClick={() => {
+          updateSidebar(
+            <AlbumSidebar albumId={album.id} albumTitle={album.title} />
+          )
+        }}
+      >
+        <GearIcon />
+      </button>
     </div>
   )
 }

--- a/ui/src/components/album/AlbumTitle.tsx
+++ b/ui/src/components/album/AlbumTitle.tsx
@@ -26,7 +26,7 @@ export const BreadcrumbList = styled.ol<{ hideLastArrow?: boolean }>`
   }
 `
 
-const ALBUM_PATH_QUERY = gql`
+export const ALBUM_PATH_QUERY = gql`
   query albumPathQuery($id: ID!) {
     album(id: $id) {
       id

--- a/ui/src/components/sidebar/AlbumSidebar.test.tsx
+++ b/ui/src/components/sidebar/AlbumSidebar.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { MockedProvider } from '@apollo/client/testing'
+import AlbumSidebar from './AlbumSidebar'
+import { SHARE_ALBUM_QUERY } from './Sharing'
+
+import * as authentication from '../../helpers/authentication'
+
+vi.mock('../../helpers/authentication.ts')
+
+const authToken = vi.mocked(authentication.authToken)
+
+describe('AlbumSidebar', () => {
+  test('render sidebar, unauthorized', () => {
+    authToken.mockImplementation(() => null)
+
+    const { getByText, queryByText } = render(
+      <AlbumSidebar albumId="30" albumTitle="testingTitle" />
+    )
+
+    expect(getByText('testingTitle')).toBeInTheDocument()
+    expect(getByText('Download')).toBeInTheDocument()
+
+    expect(queryByText('Sharing options')).not.toBeInTheDocument()
+    expect(queryByText('Album cover')).not.toBeInTheDocument()
+  })
+
+  test('render sidebar, authorized', async () => {
+    authToken.mockImplementation(() => 'token-here')
+    const shareMock = {
+      request: { query: SHARE_ALBUM_QUERY, variables: { id: '30' } },
+      result: {
+        data: {
+          album: {
+            id: '30',
+            shares: [
+              {
+                id: '6',
+                token: 'qDSL5I1N',
+                hasPassword: false,
+                __typename: 'ShareToken',
+              },
+            ],
+            __typename: 'Album',
+          },
+        },
+      },
+    }
+    const { getByText } = render(
+      <MockedProvider mocks={[shareMock]}>
+        <AlbumSidebar albumId="30" albumTitle="testingTitle" />
+      </MockedProvider>
+    )
+    await waitFor(() => {
+      expect(getByText('testingTitle')).toBeInTheDocument()
+      expect(getByText('Download')).toBeInTheDocument()
+
+      expect(getByText('Sharing options')).toBeInTheDocument()
+
+      expect(getByText('Album cover')).toBeInTheDocument()
+    })
+  })
+})

--- a/ui/src/components/sidebar/AlbumSidebar.tsx
+++ b/ui/src/components/sidebar/AlbumSidebar.tsx
@@ -1,56 +1,40 @@
 import React from 'react'
-import { useQuery, gql } from '@apollo/client'
 import { SidebarAlbumShare } from './Sharing'
 import { useTranslation } from 'react-i18next'
 import SidebarHeader from './SidebarHeader'
-import {
-  getAlbumSidebar,
-  getAlbumSidebarVariables,
-} from './__generated__/getAlbumSidebar'
+import { authToken } from '../../helpers/authentication'
 import { SidebarAlbumCover } from './AlbumCovers'
 import SidebarAlbumDownload from './SidebarDownloadAlbum'
 
-const albumQuery = gql`
-  query getAlbumSidebar($id: ID!) {
-    album(id: $id) {
-      id
-      title
-    }
-  }
-`
-
 type AlbumSidebarProps = {
   albumId: string
+  albumTitle: string
 }
 
-const AlbumSidebar = ({ albumId }: AlbumSidebarProps) => {
+const AlbumSidebar = ({ albumId, albumTitle }: AlbumSidebarProps) => {
   const { t } = useTranslation()
-  const { loading, error, data } = useQuery<
-    getAlbumSidebar,
-    getAlbumSidebarVariables
-  >(albumQuery, {
-    variables: { id: albumId },
-  })
-
-  if (loading) return <div>{t('general.loading.default', 'Loading...')}</div>
-  if (error) return <div>{error.message}</div>
 
   return (
     <div>
       {/* <p>{t('sidebar.album.title', 'Album options')}</p> */}
       <SidebarHeader
         title={
-          data?.album.title ??
-          t('sidebar.album.title_placeholder', 'Album title')
+          albumTitle ?? t('sidebar.album.title_placeholder', 'Album title')
         }
       />
-      <div className="mt-8">
-        {/* <h1 className="text-3xl font-semibold">{data.album.title}</h1> */}
-        <SidebarAlbumShare id={albumId} />
-      </div>
-      <div className="mt-8">
-        <SidebarAlbumCover id={albumId} />
-      </div>
+      {/* don't show albumShare when authToken not available */}
+      {authToken() && (
+        <div className="mt-8">
+          {/* <h1 className="text-3xl font-semibold">{data.album.title}</h1> */}
+          <SidebarAlbumShare id={albumId} />
+        </div>
+      )}
+      {/* don't show albumCover when authToken not available */}
+      {authToken() && (
+        <div className="mt-8">
+          <SidebarAlbumCover id={albumId} />
+        </div>
+      )}
       <div className="mt-8">
         <SidebarAlbumDownload albumID={albumId} />
       </div>

--- a/ui/src/components/sidebar/Sharing.tsx
+++ b/ui/src/components/sidebar/Sharing.tsx
@@ -60,7 +60,7 @@ const SHARE_PHOTO_QUERY = gql`
   }
 `
 
-const SHARE_ALBUM_QUERY = gql`
+export const SHARE_ALBUM_QUERY = gql`
   query sidebarGetAlbumShares($id: ID!) {
     album(id: $id) {
       id

--- a/ui/src/components/sidebar/SidebarDownloadAlbum.test.tsx
+++ b/ui/src/components/sidebar/SidebarDownloadAlbum.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import SidebarDownloadAlbum, {
   generateDownloadUrl,
 } from './SidebarDownloadAlbum'
@@ -51,5 +52,14 @@ describe('SidebarDownloadAlbum', () => {
     })
 
     expect(url).toContain('/download/album/30/original')
+  })
+
+  test('render downloadAlbum and click the original "button", authorized', async () => {
+    authToken.mockImplementation(() => 'token-here')
+
+    render(<SidebarDownloadAlbum albumID="30" />)
+
+    await userEvent.click(screen.getByText('Originals'))
+    expect(window.location.href).toContain('/download/album/30/original')
   })
 })

--- a/ui/src/components/sidebar/SidebarDownloadAlbum.test.tsx
+++ b/ui/src/components/sidebar/SidebarDownloadAlbum.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import SidebarDownloadAlbum, {
+  generateDownloadUrl,
+} from './SidebarDownloadAlbum'
+
+import * as authentication from '../../helpers/authentication'
+
+vi.mock('../../helpers/authentication.ts')
+
+const authToken = vi.mocked(authentication.authToken)
+
+describe('SidebarDownloadAlbum', () => {
+  test('render downloadAlbum, unauthorized', () => {
+    authToken.mockImplementation(() => null)
+
+    render(<SidebarDownloadAlbum albumID="30" />)
+
+    // check if the download is the title
+    const h2 = document.querySelector('h2')
+    expect(h2?.textContent).toMatch(/Download/)
+  })
+
+  test('generate correct url, unauthorized as share', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('http://localhost:1234/share/qDSL5I1N'),
+      configurable: true,
+    })
+
+    authToken.mockImplementation(() => null)
+    const url = generateDownloadUrl('30', {
+      title: 'testAlbum',
+      description: '',
+      purpose: 'original',
+    })
+
+    expect(url).toContain('/download/album/30/original?token=qDSL5I1N')
+  })
+
+  test('generate correct url, authorized as share', () => {
+    Object.defineProperty(window, 'location', {
+      value: new URL('http://localhost:1234/album/30'),
+      configurable: true,
+    })
+
+    authToken.mockImplementation(() => 'token-here')
+    const url = generateDownloadUrl('30', {
+      title: 'testAlbum',
+      description: '',
+      purpose: 'original',
+    })
+
+    expect(url).toContain('/download/album/30/original')
+  })
+})

--- a/ui/src/components/sidebar/SidebarDownloadAlbum.tsx
+++ b/ui/src/components/sidebar/SidebarDownloadAlbum.tsx
@@ -9,6 +9,26 @@ type SidebarAlbumDownladProps = {
   albumID: string
 }
 
+export const generateDownloadUrl = (
+  albumID: string,
+  downloadType: {
+    title: string
+    description: string
+    purpose: string
+  }
+) => {
+  let url = `${API_ENDPOINT}/download/album/${albumID}/${downloadType.purpose}`
+  if (authToken() == null) {
+    // Try to get share token if not authorized
+    const token = location.pathname.match(/^\/share\/([\d\w]+)(\/?.*)$/)
+    if (token) {
+      // add token if found previously
+      url += `?token=${token[1]}`
+    }
+  }
+  return url
+}
+
 const SidebarAlbumDownload = ({ albumID }: SidebarAlbumDownladProps) => {
   const { t } = useTranslation()
 
@@ -54,14 +74,7 @@ const SidebarAlbumDownload = ({ albumID }: SidebarAlbumDownladProps) => {
     <SidebarTable.Row
       key={x.purpose}
       onClick={() => {
-        let url = `${API_ENDPOINT}/download/album/${albumID}/${x.purpose}`
-        if (authToken() == null) {
-          // Get share token if not authorized
-          const token = location.pathname.match(/^\/share\/([\d\w]+)(\/?.*)$/)
-          if (token) {
-            url += `?token=${token[1]}`
-          }
-        }
+        const url = generateDownloadUrl(albumID, x)
         return (location.href = url)
       }}
       tabIndex={0}

--- a/ui/src/components/sidebar/SidebarDownloadAlbum.tsx
+++ b/ui/src/components/sidebar/SidebarDownloadAlbum.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { API_ENDPOINT } from '../../apolloClient'
 import { SidebarSection, SidebarSectionTitle } from './SidebarComponents'
 import SidebarTable from './SidebarTable'
+import { authToken } from '../../helpers/authentication'
 
 type SidebarAlbumDownladProps = {
   albumID: string
@@ -52,9 +53,17 @@ const SidebarAlbumDownload = ({ albumID }: SidebarAlbumDownladProps) => {
   const downloadRows = downloads.map(x => (
     <SidebarTable.Row
       key={x.purpose}
-      onClick={() =>
-        (location.href = `${API_ENDPOINT}/download/album/${albumID}/${x.purpose}`)
-      }
+      onClick={() => {
+        let url = `${API_ENDPOINT}/download/album/${albumID}/${x.purpose}`
+        if (authToken() == null) {
+          // Get share token if not authorized
+          const token = location.pathname.match(/^\/share\/([\d\w]+)(\/?.*)$/)
+          if (token) {
+            url += `?token=${token[1]}`
+          }
+        }
+        return (location.href = url)
+      }}
       tabIndex={0}
     >
       <td className="pl-4 py-2">{`${x.title}`}</td>


### PR DESCRIPTION
This PR adds the ability to show the sidebar in the album view, so that the whole album can be downloaded (for anonymous share users).

This should close https://github.com/photoview/photoview/issues/613

In [AlbumSidebar.tsx](https://github.com/photoview/photoview/compare/master...derqurps:photoview:share_download_pictures?expand=1#diff-4e4ae8cd9a347342034080292fc5fdd3a7f6b65a18a4e172dc87b365776b3330), i removed the graphql request, as it was used only for fetching the album title. And the title is available in the calling file [AlbumTitle.tsx](ui/src/components/album/AlbumTitle.tsx), so i passed it along from there.