### PR TITLE
Fix wrap nil error

### DIFF
--- a/api/scanner/scanner_tasks/processing_tasks/process_video_task.go
+++ b/api/scanner/scanner_tasks/processing_tasks/process_video_task.go
@@ -225,7 +225,7 @@ func ReadVideoStreamMetadata(videoPath string) (*ffprobe.Stream, error) {
 
 	stream := data.FirstVideoStream()
 	if stream == nil {
-		return nil, errors.Wrapf(err, "could not get stream from file metadata (%s)", path.Base(videoPath))
+		return nil, errors.New(fmt.Sprintf("could not get stream from file metadata (%s)", path.Base(videoPath)))
 	}
 
 	return stream, nil


### PR DESCRIPTION
In this case ReadVideoStreamMetadata return nil, nil because: 

```
func Wrap(err error, message string) error {
	if err == nil {
		return nil
	}
	.....
}
```