### PR TITLE
Fix cache flag in dependencies workflow.

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -49,6 +49,7 @@ jobs:
           images: ${{ env.DOCKER_IMAGE }}
           # Docker tags based on the following events/attributes
           tags: |
+            type=raw,value=latest
             type=sha
 
       - name: Build and push

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -62,7 +62,7 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: ${{ env.IS_CACHING == 'true' && 'type=gha' }}
           cache-to: ${{ env.IS_CACHING == 'true' && 'type=gha,mode=max' }}
-          no-cache: ${{ ! env.IS_CACHING }}
+          no-cache: ${{ env.IS_CACHING != 'true' }}
           sbom: true
           provenance: mode=max
           annotations: ${{ steps.docker_meta.outputs.annotations }}


### PR DESCRIPTION
[Images](https://hub.docker.com/r/viktorstrate/dependencies/tags) are already pushed to Docker Hub. Pushing cache fails.

```
2024-09-13T09:58:20.6939814Z #84 exporting cache to registry
2024-09-13T09:58:20.6940171Z #84 preparing build cache for export
2024-09-13T09:58:20.8546297Z #84 writing layer sha256:01a842ec8147ad659fa8934536853b16bbc46c0a3128c25d18a2b49f40e520b5
2024-09-13T09:58:21.0471441Z #84 preparing build cache for export 0.4s done
2024-09-13T09:58:21.0472641Z #84 writing layer sha256:01a842ec8147ad659fa8934536853b16bbc46c0a3128c25d18a2b49f40e520b5 0.2s done
2024-09-13T09:58:21.0474733Z #84 ERROR: error writing layer blob: push access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
2024-09-13T09:58:21.0476149Z 
```

As the ENV is a string, it can't use `!` expression. Change to a condition.

Also add `latest` tag for images.