### PR TITLE
Use self-building dependencies and update the code with imagemagick.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,16 +2,16 @@ name: Docker builds
 
 on:
   push:
-    branches: ['*']
+    branches: [master]
     tags:
       - v*
   pull_request:
     branches: [master]
 
 env:
-  IS_PUSHING_IMAGES: ${{ github.event_name != 'pull_request' && github.repository == 'googollee/photoview' }}
+  IS_PUSHING_IMAGES: ${{ github.event_name != 'pull_request' && github.repository == 'photoview/photoview' }}
   DOCKER_USERNAME: viktorstrate
-  DOCKER_IMAGE: ghcr.io/googollee/photoview
+  DOCKER_IMAGE: viktorstrate/photoview
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
   PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
@@ -37,11 +37,8 @@ jobs:
         if: ${{ env.IS_PUSHING_IMAGES == 'true' }}
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          # username: ${{ env.DOCKER_USERNAME }}
-          # password: ${{ env.DOCKER_PASSWORD }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Docker meta
         id: docker_meta

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,18 +2,18 @@ name: Docker builds
 
 on:
   push:
-    branches: [master]
+    branches: ['*']
     tags:
       - v*
   pull_request:
     branches: [master]
 
 env:
-  IS_PUSHING_IMAGES: ${{ github.event_name != 'pull_request' && github.repository == 'photoview/photoview' }}
+  IS_PUSHING_IMAGES: ${{ github.event_name != 'pull_request' && github.repository == 'googollee/photoview' }}
   DOCKER_USERNAME: viktorstrate
-  DOCKER_IMAGE: viktorstrate/photoview
+  DOCKER_IMAGE: ghcr.io/googollee/photoview
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 jobs:
   build:
@@ -37,8 +37,11 @@ jobs:
         if: ${{ env.IS_PUSHING_IMAGES == 'true' }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          # username: ${{ env.DOCKER_USERNAME }}
+          # password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Docker meta
         id: docker_meta

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -61,8 +61,8 @@ jobs:
           push: ${{ env.IS_PUSHING_IMAGES }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: ${{ ( env.IS_CACHING == 'true' && 'type=gha' ) || '' }}
-          cache-to: ${{ ( env.IS_CACHING == 'true' && 'type=gha,mode=max' ) || '' }}
+          cache-from: ${{ env.IS_CACHING == 'true' && 'type=gha' }}
+          cache-to: ${{ env.IS_CACHING == 'true' && 'type=gha,mode=max' }}
           no-cache: ${{ env.IS_CACHING != 'true' }}
           sbom: true
           provenance: mode=max

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,7 +15,7 @@ env:
   DOCKER_USERNAME: viktorstrate
   DOCKER_IMAGE: viktorstrate/dependencies
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 jobs:
   build:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -61,8 +61,8 @@ jobs:
           push: ${{ env.IS_PUSHING_IMAGES }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-          cache-from: ${{ env.IS_CACHING == 'true' && 'type=gha' }}
-          cache-to: ${{ env.IS_CACHING == 'true' && 'type=gha,mode=max' }}
+          cache-from: ${{ ( env.IS_CACHING == 'true' && 'type=gha' ) || '' }}
+          cache-to: ${{ ( env.IS_CACHING == 'true' && 'type=gha,mode=max' ) || '' }}
           no-cache: ${{ env.IS_CACHING != 'true' }}
           sbom: true
           provenance: mode=max

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: ['*']
   pull_request:
     branches: [master]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: ['*']
+    branches: [master]
   pull_request:
     branches: [master]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,13 +49,28 @@ ENV PATH="${GOPATH}/bin:${PATH}"
 ENV CGO_ENABLED=1
 
 # Download dependencies
-COPY scripts/*.sh /app/scripts/
+COPY scripts/set_compiler_env.sh /app/scripts/
 RUN chmod +x /app/scripts/*.sh \
+  && source /app/scripts/set_compiler_env.sh
+
+COPY --from=viktorstrate/dependencies /artifacts.tar.gz /dependencies/
+RUN export $(cat /env) \
+  && cd /dependencies/ \
+  && tar xfv artifacts.tar.gz \
+  && cp -a include/* /usr/local/include/ \
+  && cp -a pkgconfig/* ${PKG_CONFIG_PATH} \
+  && cp -a lib/* /usr/local/lib/ \
+  && cp -a bin/* /usr/local/bin/ \
+  && apt-get install -y ./deb/jellyfin-ffmpeg.deb
+
+COPY scripts/install_*.sh /app/scripts/
+RUN chmod +x /app/scripts/*.sh \
+  && export $(cat /env) \
   && /app/scripts/install_build_dependencies.sh \
   && /app/scripts/install_runtime_dependencies.sh
 
 COPY api/go.mod api/go.sum /app/api/
-RUN source /app/scripts/set_compiler_env.sh \
+RUN export $(cat /env) \
   && go env \
   && go mod download \
   # Patch go-face
@@ -66,29 +81,43 @@ RUN source /app/scripts/set_compiler_env.sh \
     github.com/Kagami/go-face
 
 COPY api /app/api
-RUN source /app/scripts/set_compiler_env.sh \
+RUN export $(cat /env) \
+  && go env \
   && go build -v -o photoview .
 
 ### Build release image ###
-FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:bookworm-slim AS release
+FROM debian:bookworm-slim AS release
 ARG TARGETPLATFORM
 
 # See for details: https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
 COPY scripts/install_runtime_dependencies.sh /app/scripts/
-RUN chmod +x /app/scripts/install_runtime_dependencies.sh \
+RUN --mount=type=bind,from=api,source=/dependencies/,target=/dependencies/ \
+  chmod +x /app/scripts/install_runtime_dependencies.sh \
   # Create a user to run Photoview server
   && groupadd -g 999 photoview \
   && useradd -r -u 999 -g photoview -m photoview \
-  # Required dependencies
-  && /app/scripts/install_runtime_dependencies.sh
-
-WORKDIR /home/photoview
+  # Install required dependencies
+  && /app/scripts/install_runtime_dependencies.sh \
+  # Install self-building libs
+  && cd /dependencies \
+  && cp -a lib/* /usr/local/lib/ \
+  && cp -a bin/* /usr/local/bin/ \
+  && ldconfig \
+  && apt-get install -y ./deb/jellyfin-ffmpeg.deb \
+  && ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ \
+  && ln -s /usr/lib/jellyfin-ffmpeg/ffprobe /usr/local/bin/ \
+  # Cleanup
+  && apt-get autoremove -y \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY api/data /app/data
 COPY --from=ui /app/ui/dist /app/ui
 COPY --from=api /app/api/photoview /app/photoview
+
+WORKDIR /home/photoview
 
 ENV PHOTOVIEW_LISTEN_IP=127.0.0.1
 ENV PHOTOVIEW_LISTEN_PORT=80

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN export $(cat /env) \
   && cp -a pkgconfig/* ${PKG_CONFIG_PATH} \
   && cp -a lib/* /usr/local/lib/ \
   && cp -a bin/* /usr/local/bin/ \
+  && ldconfig \
   && apt-get install -y ./deb/jellyfin-ffmpeg.deb
 
 COPY scripts/install_*.sh /app/scripts/

--- a/api/go.mod
+++ b/api/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/stretchr/testify v1.9.0
-	github.com/strukturag/libheif v1.15.1
+	github.com/strukturag/libheif v1.18.2
 	github.com/vektah/gqlparser/v2 v2.5.16
 	github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0
 	github.com/xor-gate/goexif2 v1.1.0
@@ -41,12 +41,12 @@ require (
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.6.0 // indirect
-	github.com/jackc/puddle/v2 v2.2.1 // indirect
+	github.com/jackc/pgx/v5 v5.7.1 // indirect
+	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/kr/text v0.1.0 // indirect
-	github.com/mattn/go-sqlite3 v1.14.22 // indirect
+	github.com/mattn/go-sqlite3 v1.14.23 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -48,10 +48,10 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.6.0 h1:SWJzexBzPL5jb0GEsrPMLIsi/3jOo7RHlzTjcAeDrPY=
-github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
-github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
-github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
+github.com/jackc/pgx/v5 v5.7.1 h1:x7SYsPBYDkHDksogeSmZZ5xzThcTgRz++I5E+ePFUcs=
+github.com/jackc/pgx/v5 v5.7.1/go.mod h1:e7O26IywZZ+naJtWWos6i6fvWK+29etgITqrqHLfoZA=
+github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
+github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
@@ -63,8 +63,8 @@ github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NB
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
-github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mattn/go-sqlite3 v1.14.23 h1:gbShiuAP1W5j9UOksQ06aiiqPMxYecovVGwmTxWtuw0=
+github.com/mattn/go-sqlite3 v1.14.23/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
@@ -91,8 +91,8 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/strukturag/libheif v1.15.1 h1:PWMRTk+9HG0a9avvlV597iI0AdHk25zKVV33lSl6a+I=
-github.com/strukturag/libheif v1.15.1/go.mod h1:E/PNRlmVtrtj9j2AvBZlrO4dsBDu6KfwDZn7X1Ce8Ks=
+github.com/strukturag/libheif v1.18.2 h1:CrlRS7Kwl2odl4DYM/m6ay/HPXEcmQPK1xF8FxAqP7k=
+github.com/strukturag/libheif v1.18.2/go.mod h1:E/PNRlmVtrtj9j2AvBZlrO4dsBDu6KfwDZn7X1Ce8Ks=
 github.com/urfave/cli/v2 v2.27.2 h1:6e0H+AkS+zDckwPCUrZkKX38mRaau4nL2uipkJpbkcI=
 github.com/urfave/cli/v2 v2.27.2/go.mod h1:g0+79LmHHATl7DAcHO99smiR/T7uGLw84w8Y42x+4eM=
 github.com/vektah/gqlparser/v2 v2.5.16 h1:1gcmLTvs3JLKXckwCwlUagVn/IlV2bwqle0vJ0vy5p8=

--- a/api/scanner/media_encoding/encode_photo.go
+++ b/api/scanner/media_encoding/encode_photo.go
@@ -22,12 +22,12 @@ import (
 )
 
 var thumbFilter = map[models.ThumbnailFilter]imaging.ResampleFilter{
-	models.ThumbnailFilterNearestNeighbor:  imaging.NearestNeighbor,
-	models.ThumbnailFilterBox:  imaging.Box,
-	models.ThumbnailFilterLinear:	imaging.Linear,
-	models.ThumbnailFilterMitchellNetravali:	imaging.MitchellNetravali,
-	models.ThumbnailFilterCatmullRom:	imaging.CatmullRom,
-	models.ThumbnailFilterLanczos:	imaging.Lanczos,
+	models.ThumbnailFilterNearestNeighbor:   imaging.NearestNeighbor,
+	models.ThumbnailFilterBox:               imaging.Box,
+	models.ThumbnailFilterLinear:            imaging.Linear,
+	models.ThumbnailFilterMitchellNetravali: imaging.MitchellNetravali,
+	models.ThumbnailFilterCatmullRom:        imaging.CatmullRom,
+	models.ThumbnailFilterLanczos:           imaging.Lanczos,
 }
 
 func EncodeThumbnail(db *gorm.DB, inputPath string, outputPath string) (*media_utils.PhotoDimensions, error) {
@@ -108,10 +108,10 @@ func (img *EncodeMediaData) EncodeHighRes(outputPath string) error {
 		return errors.New("could not convert photo as file format is not supported")
 	}
 
-	// Use darktable if there is no counterpart JPEG file to use instead
+	// Use magick if there is no counterpart JPEG file to use instead
 	if contentType.IsRaw() && img.CounterpartPath == nil {
-		if executable_worker.DarktableCli.IsInstalled() {
-			err := executable_worker.DarktableCli.EncodeJpeg(img.Media.Path, outputPath, 70)
+		if executable_worker.Magick.IsInstalled() {
+			err := executable_worker.Magick.EncodeJpeg(img.Media.Path, outputPath, 70)
 			if err != nil {
 				return err
 			}

--- a/api/scanner/media_encoding/executable_worker/executable_worker.go
+++ b/api/scanner/media_encoding/executable_worker/executable_worker.go
@@ -2,9 +2,7 @@ package executable_worker
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
-	"os"
 	"os/exec"
 	"strings"
 
@@ -14,49 +12,19 @@ import (
 )
 
 func InitializeExecutableWorkers() {
-	DarktableCli = newDarktableWorker()
+	Magick = newMagickCli()
 	FfmpegCli = newFfmpegWorker()
 }
 
-var DarktableCli *DarktableWorker = nil
+var Magick *MagickCli = nil
 var FfmpegCli *FfmpegWorker = nil
 
 type ExecutableWorker interface {
 	Path() string
 }
 
-type DarktableWorker struct {
-	path string
-}
-
 type FfmpegWorker struct {
 	path string
-}
-
-func newDarktableWorker() *DarktableWorker {
-	if utils.EnvDisableRawProcessing.GetBool() {
-		log.Printf("Executable worker disabled (%s=1): darktable\n", utils.EnvDisableRawProcessing.GetName())
-		return nil
-	}
-
-	path, err := exec.LookPath("darktable-cli")
-	if err != nil {
-		log.Println("Executable worker not found: darktable")
-	} else {
-		version, err := exec.Command(path, "--version").Output()
-		if err != nil {
-			log.Printf("Error getting version of darktable: %s\n", err)
-			return nil
-		}
-
-		log.Printf("Found executable worker: darktable (%s)\n", strings.Split(string(version), "\n")[0])
-
-		return &DarktableWorker{
-			path: path,
-		}
-	}
-
-	return nil
 }
 
 func newFfmpegWorker() *FfmpegWorker {
@@ -85,38 +53,8 @@ func newFfmpegWorker() *FfmpegWorker {
 	return nil
 }
 
-func (worker *DarktableWorker) IsInstalled() bool {
-	return worker != nil
-}
-
 func (worker *FfmpegWorker) IsInstalled() bool {
 	return worker != nil
-}
-
-func (worker *DarktableWorker) EncodeJpeg(inputPath string, outputPath string, jpegQuality int) error {
-	tmpDir, err := ioutil.TempDir("/tmp", "photoview-darktable")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	args := []string{
-		inputPath,
-		outputPath,
-		"--core",
-		"--conf",
-		fmt.Sprintf("plugins/imageio/format/jpeg/quality=%d", jpegQuality),
-		"--configdir",
-		tmpDir,
-	}
-
-	cmd := exec.Command(worker.path, args...)
-
-	if err := cmd.Run(); err != nil {
-		return errors.Wrapf(err, "encoding image using: %s %v", worker.path, args)
-	}
-
-	return nil
 }
 
 func (worker *FfmpegWorker) EncodeMp4(inputPath string, outputPath string) error {

--- a/api/scanner/media_encoding/executable_worker/executable_worker_test.go
+++ b/api/scanner/media_encoding/executable_worker/executable_worker_test.go
@@ -33,3 +33,11 @@ func setPathWithCurrent(paths ...string) func() {
 		os.Setenv("PATH", originalPath)
 	}
 }
+
+func setEnv(key, value string) func() {
+	org := os.Getenv(key)
+	os.Setenv(key, value)
+	return func() {
+		os.Setenv(key, org)
+	}
+}

--- a/api/scanner/media_encoding/executable_worker/magick_cli.go
+++ b/api/scanner/media_encoding/executable_worker/magick_cli.go
@@ -1,0 +1,60 @@
+package executable_worker
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strings"
+
+	"github.com/photoview/photoview/api/utils"
+)
+
+type MagickCli struct {
+	path string
+}
+
+func newMagickCli() *MagickCli {
+	if utils.EnvDisableRawProcessing.GetBool() {
+		log.Printf("Executable worker disabled (%s=1): ImageMagick\n", utils.EnvDisableRawProcessing.GetName())
+		return nil
+	}
+
+	path, err := exec.LookPath("magick")
+	if err != nil {
+		log.Println("Executable worker not found: magick")
+		return nil
+	}
+
+	version, err := exec.Command(path, "-version").Output()
+	if err != nil {
+		log.Printf("Error getting version of magick: %s\n", err)
+		return nil
+	}
+
+	log.Printf("Found executable worker: magick (%s)\n", strings.Split(string(version), "\n")[0])
+
+	return &MagickCli{
+		path: path,
+	}
+}
+
+func (cli *MagickCli) IsInstalled() bool {
+	return cli != nil
+}
+
+func (cli *MagickCli) EncodeJpeg(inputPath string, outputPath string, jpegQuality int) error {
+	args := []string{
+		"convert",
+		inputPath,
+		"-quality", fmt.Sprintf("%d", jpegQuality),
+		outputPath,
+	}
+
+	cmd := exec.Command(cli.path, args...)
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("encoding image with \"%s %v\" error: %w", cli.path, args, err)
+	}
+
+	return nil
+}

--- a/api/scanner/media_encoding/executable_worker/magick_cli.go
+++ b/api/scanner/media_encoding/executable_worker/magick_cli.go
@@ -15,7 +15,7 @@ type MagickCli struct {
 
 func newMagickCli() *MagickCli {
 	if utils.EnvDisableRawProcessing.GetBool() {
-		log.Printf("Executable worker disabled (%s=1): ImageMagick\n", utils.EnvDisableRawProcessing.GetName())
+		log.Printf("Executable worker disabled (%s=%q): ImageMagick\n", utils.EnvDisableRawProcessing.GetName(), utils.EnvDisableRawProcessing.GetValue())
 		return nil
 	}
 

--- a/api/scanner/media_encoding/executable_worker/magick_cli_test.go
+++ b/api/scanner/media_encoding/executable_worker/magick_cli_test.go
@@ -1,0 +1,70 @@
+package executable_worker_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/photoview/photoview/api/scanner/media_encoding/executable_worker"
+)
+
+func TestMagickCliNotExist(t *testing.T) {
+	done := setPathWithCurrent()
+	defer done()
+
+	executable_worker.InitializeExecutableWorkers()
+	if executable_worker.Magick.IsInstalled() {
+		t.Error("MagickCli should not be installed, but is found:", executable_worker.Magick)
+	}
+}
+
+func TestMagickCliIgnore(t *testing.T) {
+	donePath := setPathWithCurrent("./testdata/bin")
+	defer donePath()
+
+	doneDisableRaw := setEnv("PHOTOVIEW_DISABLE_RAW_PROCESSING", "true")
+	defer doneDisableRaw()
+
+	executable_worker.InitializeExecutableWorkers()
+	if executable_worker.Magick.IsInstalled() {
+		t.Error("MagickCli should not be installed, but is found:", executable_worker.Magick)
+	}
+}
+
+func TestMagickCliFail(t *testing.T) {
+	donePath := setPathWithCurrent("./testdata/bin")
+	defer donePath()
+
+	executable_worker.InitializeExecutableWorkers()
+	if !executable_worker.Magick.IsInstalled() {
+		t.Fatal("MagickCli should be installed")
+	}
+
+	done := setEnv("FAIL_WITH", "failure")
+	defer done()
+
+	err := executable_worker.Magick.EncodeJpeg("input", "output", 70)
+	if err == nil {
+		t.Fatalf(`MagickCli.EncodeJpeg(...) = nil, should be an error.`)
+	}
+
+	if got, want := err.Error(), `^encoding image with ".*/testdata/bin/magick \[convert input -quality 70 output\]" error: .*$`; !regexp.MustCompile(want).MatchString(got) {
+		t.Errorf(`MagickCli.EncodeJpeg(...) = %q, should be matched with reg pattern %q`, got, want)
+	}
+}
+
+func TestMagickCliSucceed(t *testing.T) {
+	donePath := setPathWithCurrent("./testdata/bin")
+	defer donePath()
+
+	executable_worker.InitializeExecutableWorkers()
+	if !executable_worker.Magick.IsInstalled() {
+		t.Fatal("MagickCli should be installed")
+	}
+
+	t.Run("Succeeded", func(t *testing.T) {
+		err := executable_worker.Magick.EncodeJpeg("input", "output", 70)
+		if err != nil {
+			t.Fatalf("MagickCli.EncodeJpeg(...) = %v, should be nil.", err)
+		}
+	})
+}

--- a/api/scanner/media_encoding/executable_worker/testdata/bin/magick
+++ b/api/scanner/media_encoding/executable_worker/testdata/bin/magick
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+: ${FAIL_WITH=""}
+
+if [ "$1" = "-version" ]
+then
+  echo magick: version fake
+  exit 0
+fi
+
+if [ "${FAIL_WITH}" != "" ]
+then
+  echo ${FAIL_WITH}
+  exit -1
+fi
+
+echo $@

--- a/api/scanner/media_type/media_type.go
+++ b/api/scanner/media_type/media_type.go
@@ -260,7 +260,7 @@ func (imgType *MediaType) IsSupported() bool {
 		return true
 	}
 
-	if executable_worker.DarktableCli.IsInstalled() && imgType.IsRaw() {
+	if executable_worker.Magick.IsInstalled() && imgType.IsRaw() {
 		return true
 	}
 

--- a/dependencies/prepare.sh
+++ b/dependencies/prepare.sh
@@ -11,7 +11,7 @@ DEBIAN_ARCH=$TARGETARCH
 if [ "$TARGETARCH" = "arm" ]
 then
   DEBIAN_ARCH=armhf
-  if [ "$TARGETVARIANT" = "v5" ]
+  if [ "$TARGETVARIANT" = "v5" || "$TARGETVARIANT" = "v6" ]
   then
     DEBIAN_ARCH=armel
   fi

--- a/dependencies/prepare.sh
+++ b/dependencies/prepare.sh
@@ -10,10 +10,10 @@ TARGETVARIANT="$(echo $TARGETPLATFORM | cut -d"/" -f3)"
 DEBIAN_ARCH=$TARGETARCH
 if [ "$TARGETARCH" = "arm" ]
 then
-  DEBIAN_ARCH=armhf
-  if [ "$TARGETVARIANT" = "v5" || "$TARGETVARIANT" = "v6" ]
+  DEBIAN_ARCH=armel
+  if [ "$TARGETVARIANT" = "v7" ]
   then
-    DEBIAN_ARCH=armel
+    DEBIAN_ARCH=armhf
   fi
 fi
 

--- a/dev-compose.yaml
+++ b/dev-compose.yaml
@@ -39,7 +39,7 @@ services:
     - /bin/bash
     - -c
     - |
-      source /app/scripts/set_compiler_env.sh 
+      export $(cat /env)
       reflex -g '*.go' -s -- go run .
 
   mariadb:

--- a/scripts/install_build_dependencies.sh
+++ b/scripts/install_build_dependencies.sh
@@ -4,7 +4,7 @@ set -eu
 : ${DEB_HOST_ARCH=`dpkg --print-architecture`}
 echo Arch: ${DEB_HOST_ARCH}
 
-# Install go-face dependencies and libheif for HEIF media decoding
+# Install go-face dependencies
 apt-get install -y \
   libdlib-dev:${DEB_HOST_ARCH} libblas-dev:${DEB_HOST_ARCH} libatlas-base-dev:${DEB_HOST_ARCH} liblapack-dev:${DEB_HOST_ARCH} libjpeg-dev:${DEB_HOST_ARCH}
 

--- a/scripts/install_build_dependencies.sh
+++ b/scripts/install_build_dependencies.sh
@@ -1,42 +1,21 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
-if [ "$TARGETPLATFORM" == "linux/arm64" ]; then
-  dpkg --add-architecture arm64
-  DEBIAN_ARCH='arm64'
-elif [ "$TARGETPLATFORM" == "linux/arm/v6" ] || [ "$TARGETPLATFORM" == "linux/arm/v7" ]; then
-  dpkg --add-architecture armhf
-  DEBIAN_ARCH='armhf'
-else
-  dpkg --add-architecture amd64
-  DEBIAN_ARCH='amd64'
-fi
+: ${DEB_HOST_ARCH=`dpkg --print-architecture`}
+echo Arch: ${DEB_HOST_ARCH}
 
-apt-get update
+# libraw dependencies
+apt-get install -y zlib1g-dev:${DEB_HOST_ARCH} liblcms2-dev:${DEB_HOST_ARCH} libjpeg-dev:${DEB_HOST_ARCH}
 
-# Install G++/GCC cross compilers
-if [ "$DEBIAN_ARCH" == "arm64" ]; then
-  apt-get install -y \
-    g++-aarch64-linux-gnu \
-    libc6-dev-arm64-cross
-elif [ "$DEBIAN_ARCH" == "armhf" ]; then
-  apt-get install -y \
-    g++-arm-linux-gnueabihf \
-    libc6-dev-armhf-cross
-else
-  apt-get install -y \
-    g++-x86-64-linux-gnu \
-    libc6-dev-amd64-cross
-fi
+# libheif dependencies
+apt-get install -y libaom-dev:${DEB_HOST_ARCH} libavcodec-dev:${DEB_HOST_ARCH} libdav1d-dev:${DEB_HOST_ARCH} libde265-dev:${DEB_HOST_ARCH} libgdk-pixbuf-2.0-dev:${DEB_HOST_ARCH} libjpeg-dev:${DEB_HOST_ARCH} libopenjp2-7-dev:${DEB_HOST_ARCH} libpng-dev:${DEB_HOST_ARCH} librav1e-dev:${DEB_HOST_ARCH} libsvtav1enc-dev:${DEB_HOST_ARCH} libx265-dev:${DEB_HOST_ARCH}
+
+# ImageMagick dependencies
+apt-get install -y libjxl-dev:${DEB_HOST_ARCH} libfftw3-dev:${DEB_HOST_ARCH} liblcms2-dev:${DEB_HOST_ARCH} liblqr-1-0-dev:${DEB_HOST_ARCH} zlib1g-dev:${DEB_HOST_ARCH} liblzma-dev:${DEB_HOST_ARCH} libbz2-dev:${DEB_HOST_ARCH} libdjvulibre-dev:${DEB_HOST_ARCH} libexif-dev:${DEB_HOST_ARCH} libjpeg-dev:${DEB_HOST_ARCH} libopenjp2-7-dev:${DEB_HOST_ARCH} libopenexr-dev:${DEB_HOST_ARCH} libpng-dev:${DEB_HOST_ARCH} libtiff-dev:${DEB_HOST_ARCH} libwmf-dev:${DEB_HOST_ARCH} libwebp-dev:${DEB_HOST_ARCH} libxml2-dev:${DEB_HOST_ARCH}
 
 # Install go-face dependencies and libheif for HEIF media decoding
 apt-get install -y \
-  libdlib-dev:${DEBIAN_ARCH} \
-  libblas-dev:${DEBIAN_ARCH} \
-  libatlas-base-dev:${DEBIAN_ARCH} \
-  liblapack-dev:${DEBIAN_ARCH} \
-  libjpeg-dev:${DEBIAN_ARCH} \
-  libheif-dev:${DEBIAN_ARCH}
+  libdlib-dev:${DEB_HOST_ARCH} libblas-dev:${DEB_HOST_ARCH} libatlas-base-dev:${DEB_HOST_ARCH} liblapack-dev:${DEB_HOST_ARCH} libjpeg-dev:${DEB_HOST_ARCH}
 
 # Install tools for development
 apt-get install -y reflex sqlite3

--- a/scripts/install_build_dependencies.sh
+++ b/scripts/install_build_dependencies.sh
@@ -4,15 +4,6 @@ set -eu
 : ${DEB_HOST_ARCH=`dpkg --print-architecture`}
 echo Arch: ${DEB_HOST_ARCH}
 
-# libraw dependencies
-apt-get install -y zlib1g-dev:${DEB_HOST_ARCH} liblcms2-dev:${DEB_HOST_ARCH} libjpeg-dev:${DEB_HOST_ARCH}
-
-# libheif dependencies
-apt-get install -y libaom-dev:${DEB_HOST_ARCH} libavcodec-dev:${DEB_HOST_ARCH} libdav1d-dev:${DEB_HOST_ARCH} libde265-dev:${DEB_HOST_ARCH} libgdk-pixbuf-2.0-dev:${DEB_HOST_ARCH} libjpeg-dev:${DEB_HOST_ARCH} libopenjp2-7-dev:${DEB_HOST_ARCH} libpng-dev:${DEB_HOST_ARCH} librav1e-dev:${DEB_HOST_ARCH} libsvtav1enc-dev:${DEB_HOST_ARCH} libx265-dev:${DEB_HOST_ARCH}
-
-# ImageMagick dependencies
-apt-get install -y libjxl-dev:${DEB_HOST_ARCH} libfftw3-dev:${DEB_HOST_ARCH} liblcms2-dev:${DEB_HOST_ARCH} liblqr-1-0-dev:${DEB_HOST_ARCH} zlib1g-dev:${DEB_HOST_ARCH} liblzma-dev:${DEB_HOST_ARCH} libbz2-dev:${DEB_HOST_ARCH} libdjvulibre-dev:${DEB_HOST_ARCH} libexif-dev:${DEB_HOST_ARCH} libjpeg-dev:${DEB_HOST_ARCH} libopenjp2-7-dev:${DEB_HOST_ARCH} libopenexr-dev:${DEB_HOST_ARCH} libpng-dev:${DEB_HOST_ARCH} libtiff-dev:${DEB_HOST_ARCH} libwmf-dev:${DEB_HOST_ARCH} libwebp-dev:${DEB_HOST_ARCH} libxml2-dev:${DEB_HOST_ARCH}
-
 # Install go-face dependencies and libheif for HEIF media decoding
 apt-get install -y \
   libdlib-dev:${DEB_HOST_ARCH} libblas-dev:${DEB_HOST_ARCH} libatlas-base-dev:${DEB_HOST_ARCH} liblapack-dev:${DEB_HOST_ARCH} libjpeg-dev:${DEB_HOST_ARCH}

--- a/scripts/install_runtime_dependencies.sh
+++ b/scripts/install_runtime_dependencies.sh
@@ -1,22 +1,13 @@
-#!/bin/bash
+#!/bin/sh
+set -eu
 
 apt-get update
-apt-get install -y curl libdlib19.1 ffmpeg exiftool libheif1
+apt-get install -y curl exiftool
 
-# Install Darktable if building for a supported architecture
-if [ "${TARGETPLATFORM}" = "linux/amd64" ] || [ "${TARGETPLATFORM}" = "linux/arm64" ]; then
-  echo 'deb [trusted=true] https://download.opensuse.org/repositories/graphics:/darktable/Debian_12/ /' > /etc/apt/sources.list.d/darktable.list
-  # Release key is invalid, just trust the repo
-  curl -fsSL https://download.opensuse.org/repositories/graphics:/darktable/Debian_12/Release.key \
-    | gpg --dearmor -o /etc/apt/trusted.gpg.d/darktable.gpg
-  gpg --show-keys --with-fingerprint --dry-run /etc/apt/trusted.gpg.d/darktable.gpg
-
-  apt-get update
-  apt-get install -y darktable
-fi
-
-# Remove build dependencies and cleanup
-apt-get purge -y ${BUILD_DEPENDS[@]}
-apt-get autoremove -y
-apt-get clean
-rm -rf /var/lib/apt/lists/*
+# libheif dependencies: no dependency
+# libraw dependencies
+apt-get install -y libjpeg62-turbo liblcms2-2
+# ImageMagick dependencies
+apt-get install -y libjbig0 libtiff6 libfreetype6 libjxl0.7 liblqr-1-0 libpng16-16 libdjvulibre21 libwebpmux3 libwebpdemux2 libwebp7 libopenexr-3-1-30 libopenjp2-7 libjpeg62-turbo liblcms2-2 libxml2 libx11-6 libgomp1
+# go-face dependencies
+apt-get install -y libdlib19.1 libblas3 liblapack3 libjpeg62-turbo

--- a/scripts/install_runtime_dependencies.sh
+++ b/scripts/install_runtime_dependencies.sh
@@ -2,12 +2,15 @@
 set -eu
 
 apt-get update
-apt-get install -y curl exiftool
 
-# libheif dependencies: no dependency
-# libraw dependencies
-apt-get install -y libjpeg62-turbo liblcms2-2
-# ImageMagick dependencies
-apt-get install -y libjbig0 libtiff6 libfreetype6 libjxl0.7 liblqr-1-0 libpng16-16 libdjvulibre21 libwebpmux3 libwebpdemux2 libwebp7 libopenexr-3-1-30 libopenjp2-7 libjpeg62-turbo liblcms2-2 libxml2 libx11-6 libgomp1
-# go-face dependencies
-apt-get install -y libdlib19.1 libblas3 liblapack3 libjpeg62-turbo
+apt-get install -y \
+  curl exiftool \
+  # libheif dependencies: no dependency
+  # libraw dependencies
+  libjpeg62-turbo liblcms2-2 \
+  # ImageMagick dependencies
+  libjbig0 libtiff6 libfreetype6 libjxl0.7 liblqr-1-0 libpng16-16 \
+  libdjvulibre21 libwebpmux3 libwebpdemux2 libwebp7 libopenexr-3-1-30 \
+  libopenjp2-7 libjpeg62-turbo liblcms2-2 libxml2 libx11-6 libgomp1 \
+  # go-face dependencies
+  libdlib19.1 libblas3 liblapack3 libjpeg62-turbo

--- a/scripts/install_runtime_dependencies.sh
+++ b/scripts/install_runtime_dependencies.sh
@@ -2,15 +2,12 @@
 set -eu
 
 apt-get update
+apt-get install -y curl exiftool
 
-apt-get install -y \
-  curl exiftool \
-  # libheif dependencies: no dependency
-  # libraw dependencies
-  libjpeg62-turbo liblcms2-2 \
-  # ImageMagick dependencies
-  libjbig0 libtiff6 libfreetype6 libjxl0.7 liblqr-1-0 libpng16-16 \
-  libdjvulibre21 libwebpmux3 libwebpdemux2 libwebp7 libopenexr-3-1-30 \
-  libopenjp2-7 libjpeg62-turbo liblcms2-2 libxml2 libx11-6 libgomp1 \
-  # go-face dependencies
-  libdlib19.1 libblas3 liblapack3 libjpeg62-turbo
+# libheif dependencies: no dependency
+# libraw dependencies
+apt-get install -y libjpeg62-turbo liblcms2-2
+# ImageMagick dependencies
+apt-get install -y libjbig0 libtiff6 libfreetype6 libjxl0.7 liblqr-1-0 libpng16-16 libdjvulibre21 libwebpmux3 libwebpdemux2 libwebp7 libopenexr-3-1-30 libopenjp2-7 libjpeg62-turbo liblcms2-2 libxml2 libx11-6 libgomp1
+# go-face dependencies
+apt-get install -y libdlib19.1 libblas3 liblapack3 libjpeg62-turbo

--- a/scripts/set_compiler_env.sh
+++ b/scripts/set_compiler_env.sh
@@ -13,7 +13,7 @@ DEBIAN_ARCH=$TARGETARCH
 if [ "$TARGETARCH" = "arm" ]
 then
   DEBIAN_ARCH=armhf
-  if [ "$TARGETVARIANT" = "v5" ]
+  if [ "$TARGETVARIANT" = "v5" || "$TARGETVARIANT" = "v6" ]
   then
     DEBIAN_ARCH=armel
   fi

--- a/scripts/set_compiler_env.sh
+++ b/scripts/set_compiler_env.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-# Script to configure environment variables for  compiler to cross compilation
+# Configure environment for cross-compiling.
 
 : ${TARGETPLATFORM=linux/`dpkg --print-architecture`}
 
@@ -12,10 +12,10 @@ TARGETVARIANT="$(echo $TARGETPLATFORM | cut -d"/" -f3)"
 DEBIAN_ARCH=$TARGETARCH
 if [ "$TARGETARCH" = "arm" ]
 then
-  DEBIAN_ARCH=armhf
-  if [ "$TARGETVARIANT" = "v5" || "$TARGETVARIANT" = "v6" ]
+  DEBIAN_ARCH=armel
+  if [ "$TARGETVARIANT" = "v7" ]
   then
-    DEBIAN_ARCH=armel
+    DEBIAN_ARCH=armhf
   fi
 fi
 


### PR DESCRIPTION
- Use self-building dependencies, including `libraw`/`libheif`/`imagemagick`/`jellyfin-ffmpeg`.
- Update go dependencies to the latest version, including `go-libheif`.
- Drop building `arm/v6` because of https://github.com/photoview/photoview/discussions/1051.
- Update the building scripts in favor of `dpkg-archtecture`, like how we build dependencies.
- Use `ImageMagick 7` instead of `darktable`.

Custom codec with `jellyfin-ffmpeg` will be in the following PR.