### PR TITLE
Fix #677: Support RAW image with JPEG version without installing Magick

### DIFF
--- a/api/scanner/media_type/media_type.go
+++ b/api/scanner/media_type/media_type.go
@@ -260,7 +260,7 @@ func (imgType *MediaType) IsSupported() bool {
 		return true
 	}
 
-	if executable_worker.Magick.IsInstalled() && imgType.IsRaw() {
+	if imgType.IsRaw() {
 		return true
 	}
 


### PR DESCRIPTION
This PR fix issue "When RAW processing is disabled, already existing JPG versions are also ignored #677".

According to code in EncodeHighRes(), when a RAW image has a counterpart JPEG file, there is no need to encode it to JPEG with Magick. That is, Magick isn't necessary in this situation. 

But because the installation of Magick is checked in IsSupported() when a RAW image is processed, the RAW image with counterpart JPEG file won't be displayed if Magick isn't installed.

This PR deletes the check of the installation of Magick in IsSupported() to fix it.