### PR TITLE
Fix scheduled Docker image build for latest tag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-tags: 'true'
 
       - name: Prepare the Matrix
         id: prepare_matrix


### PR DESCRIPTION
After the recent improvement of the GitHub Actions Build workflow, a new feature has been introduced: weekly building of the latest released image to regularly update the base image and its dependencies.

However, after the 1st scheduled run, it is discovered that the job doesn't see tags, even while it contains the `git fetch --all` command. Unfortunately, this functionality cannot be tested, as scheduled runs run only in `master` branch. Locally inside the `ubuntu:latest` container, it works fine with `git clone` and `git fetch --all`.

So, this PR adds an additional way to fetch tags for the repo.
If it won't help (we can see that only after the merge and run next week), there is 1 more key to try: `fetch-depth: '0'`, which downloads the whole repo history