### PR TITLE
Fix `ESLint` step in UI testing job and add CodeCov tokens

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,6 +81,7 @@ jobs:
       uses: codecov/codecov-action@v4
       if: ${{ steps.test.conclusion == 'success' }}
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: api-${{ matrix.database }}
 
   test-ui:
@@ -116,6 +117,7 @@ jobs:
       uses: codecov/codecov-action@v4
       if: ${{ steps.test.conclusion == 'success' }}
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: ui
 
     - name: Run ESLint

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,6 +13,7 @@
     "mon": "nodemon",
     "build": "vite build",
     "lint": "eslint ./src --max-warnings 0 --config .eslintrc.js",
+    "lint:ci": "eslint ./src --config .eslintrc.js --no-color --fix-dry-run > eslint-report.txt",
     "test": "vitest",
     "test:ci": "CI=true vitest --reporter verbose --run --coverage",
     "genSchemaTypes": "apollo client:codegen --target=typescript --globalTypesFile=src/__generated__/globalTypes.ts --passthroughCustomScalars && prettier --write */**/__generated__/*.ts",


### PR DESCRIPTION
Add the missing script line back to the `package.json`.
Without this line the step fails now: https://github.com/photoview/photoview/actions/runs/11160932042/job/31022414269

Also, I've added the brand-new CodeCov token to the testing jobs