### PR TITLE
Set `$NODE_ENV` according to the image purpose during Docker build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,6 +124,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
+            NODE_ENV=production
             VERSION=${{ github.ref_name }}
             COMMIT_SHA=${{ github.sha }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,8 @@ jobs:
         tags: photoview/ui
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        build-args: |
+          NODE_ENV=testing
 
     - name: Test
       id: test

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM --platform=${BUILDPLATFORM:-linux/amd64} node:18 AS ui
 # See for details: https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 
+ARG NODE_ENV
+ENV NODE_ENV=${NODE_ENV:-production}
+
 ARG REACT_APP_API_ENDPOINT
 ENV REACT_APP_API_ENDPOINT=${REACT_APP_API_ENDPOINT}
 

--- a/dev-compose.yaml
+++ b/dev-compose.yaml
@@ -7,17 +7,19 @@ services:
       context: .
       dockerfile: Dockerfile
       target: ui
+      args:
+        - NODE_ENV=development
     env_file: ui/example.env
     volumes:
-    - .:/app:rw
+      - .:/app:rw
     ports:
-    - 1234:1234
+      - 1234:1234
     command:
-    - /bin/bash
-    - -c
-    - |
-      npm ci
-      npm run mon
+      - /bin/bash
+      - -c
+      - |
+        npm ci
+        npm run mon
 
   dev-api:
     image: photoview/api
@@ -32,20 +34,20 @@ services:
       PHOTOVIEW_MYSQL_URL: photoview:photosecret@tcp(mysql)/photoview_test
       PHOTOVIEW_POSTGRES_URL: postgres://photoview:photosecret@postgres:5432/photoview_test
     volumes:
-    - .:/app:rw
+      - .:/app:rw
     ports:
-    - 4001:4001
+      - 4001:4001
     command:
-    - /bin/bash
-    - -c
-    - |
-      export $(cat /env)
-      reflex -g '*.go' -s -- go run .
+      - /bin/bash
+      - -c
+      - |
+        export $(cat /env)
+        reflex -g '*.go' -s -- go run .
 
   mariadb:
     image: mariadb:lts
     profiles:
-    - mysql
+      - mysql
     environment:
       MYSQL_DATABASE: photoview_test
       MYSQL_USER: photoview
@@ -53,31 +55,31 @@ services:
       MYSQL_RANDOM_ROOT_PASSWORD: yes
     healthcheck:
       test:
-      - CMD
-      - mariadb-admin
-      - --user=photoview
-      - --password=photosecret
-      - ping
+        - CMD
+        - mariadb-admin
+        - --user=photoview
+        - --password=photosecret
+        - ping
       interval: 20s
       timeout: 5s
       retries: 10
     expose:
-    - "3306"
+      - "3306"
 
   postgres:
     image: postgres:16-alpine
     profiles:
-    - postgres
+      - postgres
     environment:
       POSTGRES_DB: photoview_test
       POSTGRES_USER: photoview
       POSTGRES_PASSWORD: photosecret
     healthcheck:
       test:
-      - CMD
-      - pg_isready
+        - CMD
+        - pg_isready
       interval: 20s
       timeout: 5s
       retries: 10
     expose:
-    - "5432"
+      - "5432"


### PR DESCRIPTION
Fix #1087 

Defines the NODE_ENV variable at the UI build stage in Dockerfile with the default value "production".
Sets the correct value for this variable at the Docker build time in:
- CI build production image --> "production"
- CI build testing image --> "testing"
- `dev-compose.yml` for local development --> "development"

Note: the intentions, added in the `dev-compose.yml` are made by my IDE auto-formatting, as previous formatting wasn't fully compliant with YAML standard (while still working fine for Docker).