### PR TITLE
Cleanup deps.

### DIFF
--- a/dependencies/build_imagemagick.sh
+++ b/dependencies/build_imagemagick.sh
@@ -6,14 +6,14 @@ set -eu
 
 echo Compiler: ${DEB_HOST_MULTIARCH} Arch: ${DEB_HOST_ARCH}
 
-apt-get install -y libjxl-dev:${DEB_HOST_ARCH} liblcms2-dev:${DEB_HOST_ARCH} liblqr-1-0-dev:${DEB_HOST_ARCH} libdjvulibre-dev:${DEB_HOST_ARCH} libjpeg62-turbo-dev:${DEB_HOST_ARCH} libopenjp2-7-dev:${DEB_HOST_ARCH} libopenexr-dev:${DEB_HOST_ARCH} libpng-dev:${DEB_HOST_ARCH} libtiff-dev:${DEB_HOST_ARCH} libwebp-dev:${DEB_HOST_ARCH} libxml2-dev:${DEB_HOST_ARCH} libfftw3-dev:${DEB_HOST_ARCH} zlib1g-dev:${DEB_HOST_ARCH} liblzma-dev:${DEB_HOST_ARCH} libbz2-dev:${DEB_HOST_ARCH} libexif-dev:${DEB_HOST_ARCH} libwmf-dev:${DEB_HOST_ARCH}
+apt-get install -y libjxl-dev:${DEB_HOST_ARCH} liblcms2-dev:${DEB_HOST_ARCH} liblqr-1-0-dev:${DEB_HOST_ARCH} libdjvulibre-dev:${DEB_HOST_ARCH} libjpeg62-turbo-dev:${DEB_HOST_ARCH} libopenjp2-7-dev:${DEB_HOST_ARCH} libopenexr-dev:${DEB_HOST_ARCH} libpng-dev:${DEB_HOST_ARCH} libtiff-dev:${DEB_HOST_ARCH} libwebp-dev:${DEB_HOST_ARCH} libxml2-dev:${DEB_HOST_ARCH} libfftw3-dev:${DEB_HOST_ARCH} zlib1g-dev:${DEB_HOST_ARCH} liblzma-dev:${DEB_HOST_ARCH} libbz2-dev:${DEB_HOST_ARCH}
 URL=$(curl -s https://api.github.com/repos/ImageMagick/ImageMagick/releases/latest | grep "tarball_url" | cut -d : -f 2,3 | tr -d ' ,"')
 echo download ImageMagick from $URL
 curl -L -o ./magick.tar.gz "$URL"
 
 tar xfv ./magick.tar.gz
 cd ImageMagick-*
-./configure --enable-static --enable-delegate-build --disable-shared --with-x=no --host=${DEB_HOST_MULTIARCH}
+./configure --enable-64bit-channel-masks --enable-static --enable-delegate-build --disable-shared --with-x=no --with-magick-plus-plus=no --host=${DEB_HOST_MULTIARCH}
 make
 make install
 cd ..

--- a/dependencies/build_libheif.sh
+++ b/dependencies/build_libheif.sh
@@ -6,7 +6,7 @@ set -eu
 
 echo Compiler: ${DEB_HOST_MULTIARCH} Arch: ${DEB_HOST_ARCH}
 
-apt-get install -y libaom-dev:${DEB_HOST_ARCH} libdav1d-dev:${DEB_HOST_ARCH} libde265-dev:${DEB_HOST_ARCH} libjpeg62-turbo-dev:${DEB_HOST_ARCH} libnuma-dev:${DEB_HOST_ARCH} libpng-dev:${DEB_HOST_ARCH} libx265-dev:${DEB_HOST_ARCH} zlib1g-dev:${DEB_HOST_ARCH}
+apt-get install -y libdav1d-dev:${DEB_HOST_ARCH} librav1e-dev:${DEB_HOST_ARCH} libde265-dev:${DEB_HOST_ARCH} libx265-dev:${DEB_HOST_ARCH} libjpeg62-turbo-dev:${DEB_HOST_ARCH} libpng-dev:${DEB_HOST_ARCH} libnuma-dev:${DEB_HOST_ARCH} zlib1g-dev:${DEB_HOST_ARCH}
 URL=$(curl -s https://api.github.com/repos/strukturag/libheif/releases/latest | grep "tarball_url" | cut -d : -f 2,3 | tr -d ' ,"')
 echo download libraw from $URL
 curl -L -o ./libheif.tar.gz "$URL"

--- a/dependencies/build_libheif.sh
+++ b/dependencies/build_libheif.sh
@@ -6,7 +6,7 @@ set -eu
 
 echo Compiler: ${DEB_HOST_MULTIARCH} Arch: ${DEB_HOST_ARCH}
 
-apt-get install -y libdav1d-dev:${DEB_HOST_ARCH} librav1e-dev:${DEB_HOST_ARCH} libde265-dev:${DEB_HOST_ARCH} libx265-dev:${DEB_HOST_ARCH} libjpeg62-turbo-dev:${DEB_HOST_ARCH} libpng-dev:${DEB_HOST_ARCH} libnuma-dev:${DEB_HOST_ARCH} zlib1g-dev:${DEB_HOST_ARCH}
+apt-get install -y libdav1d-dev:${DEB_HOST_ARCH} libde265-dev:${DEB_HOST_ARCH} libjpeg62-turbo-dev:${DEB_HOST_ARCH} libpng-dev:${DEB_HOST_ARCH} libnuma-dev:${DEB_HOST_ARCH} zlib1g-dev:${DEB_HOST_ARCH}
 URL=$(curl -s https://api.github.com/repos/strukturag/libheif/releases/latest | grep "tarball_url" | cut -d : -f 2,3 | tr -d ' ,"')
 echo download libraw from $URL
 curl -L -o ./libheif.tar.gz "$URL"


### PR DESCRIPTION
Remove deps:

- libexif-dev: It's a old library without changes in years. ImageMagick doesn't use it.
- libwmf-dev: WMF is a Windows Document format. There is no need to support document formats for `photoview`.
  - Also removed runtime dep `libfreetype6` for WMF.
- libaom-dev: It doesn't work as av1 encoder. Instead with `librav1e-dev` for av1 encoder.