### PR TITLE
Push `dependencies` image to the new registry

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -10,10 +10,11 @@ on:
     - cron: '18 23 * * 3'
 
 env:
-  IS_PUSHING_IMAGES: ${{ github.event_name != 'pull_request' && github.repository == 'photoview/photoview' }}
+  #IS_PUSHING_IMAGES: ${{ github.event_name != 'pull_request' && github.repository == 'photoview/photoview' }}
+  IS_PUSHING_IMAGES: true
   IS_CACHING: ${{ github.event_name == 'pull_request' }}
   DOCKER_USERNAME: viktorstrate
-  DOCKER_IMAGE: viktorstrate/dependencies
+  DOCKER_IMAGE: photoview/dependencies
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
   PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -38,8 +38,10 @@ jobs:
         if: ${{ env.IS_PUSHING_IMAGES == 'true' }}
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: kkoval
+          password: dckr_pat_cqK5D6f9c2FylKI0Xhcp9LKoWlE
+          #username: ${{ env.DOCKER_USERNAME }}
+          #password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Docker meta
         id: docker_meta

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,7 +15,6 @@ env:
   IS_CACHING: ${{ github.event_name == 'pull_request' }}
   DOCKER_USERNAME: viktorstrate
   DOCKER_IMAGE: photoview/dependencies
-  DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
   PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 jobs:
@@ -40,7 +39,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
-          password: ${{ env.DOCKER_PASSWORD }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Docker meta
         id: docker_meta

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -39,7 +39,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: kkoval
-          password: dckr_pat_cqK5D6f9c2FylKI0Xhcp9LKoWlE
+          password: ${{ secrets.DOCKER_TOKEN }}
           #username: ${{ env.DOCKER_USERNAME }}
           #password: ${{ secrets.DOCKER_PASSWORD }}
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -14,7 +14,8 @@ env:
   IS_PUSHING_IMAGES: true
   IS_CACHING: ${{ github.event_name == 'pull_request' }}
   DOCKER_USERNAME: viktorstrate
-  DOCKER_IMAGE: photoview/dependencies
+  DOCKER_IMAGE: viktorstrate/dependencies
+  #DOCKER_IMAGE: photoview/dependencies
   PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 jobs:
@@ -38,10 +39,10 @@ jobs:
         if: ${{ env.IS_PUSHING_IMAGES == 'true' }}
         uses: docker/login-action@v3
         with:
-          username: kkoval
-          password: ${{ secrets.DOCKER_TOKEN }}
-          #username: ${{ env.DOCKER_USERNAME }}
-          #password: ${{ secrets.DOCKER_PASSWORD }}
+          #username: kkoval
+          #password: ${{ secrets.DOCKER_TOKEN }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Docker meta
         id: docker_meta

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -10,12 +10,10 @@ on:
     - cron: '18 23 * * 3'
 
 env:
-  #IS_PUSHING_IMAGES: ${{ github.event_name != 'pull_request' && github.repository == 'photoview/photoview' }}
-  IS_PUSHING_IMAGES: true
+  IS_PUSHING_IMAGES: ${{ github.event_name != 'pull_request' && github.repository == 'photoview/photoview' }}
   IS_CACHING: ${{ github.event_name == 'pull_request' }}
   DOCKER_USERNAME: viktorstrate
-  DOCKER_IMAGE: viktorstrate/dependencies
-  #DOCKER_IMAGE: photoview/dependencies
+  DOCKER_IMAGE: photoview/dependencies
   PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
 
 jobs:
@@ -39,8 +37,6 @@ jobs:
         if: ${{ env.IS_PUSHING_IMAGES == 'true' }}
         uses: docker/login-action@v3
         with:
-          #username: kkoval
-          #password: ${{ secrets.DOCKER_TOKEN }}
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
@@ -58,15 +54,15 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          context: ./dependencies
-          platforms: ${{ env.PLATFORMS }}
-          pull: true
-          push: ${{ env.IS_PUSHING_IMAGES }}
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+          context:     ./dependencies
+          platforms:   ${{ env.PLATFORMS }}
+          pull:        true
+          push:        ${{ env.IS_PUSHING_IMAGES }}
+          tags:        ${{ steps.docker_meta.outputs.tags }}
+          labels:      ${{ steps.docker_meta.outputs.labels }}
           annotations: ${{ steps.docker_meta.outputs.annotations }}
-          cache-from: ${{ ( env.IS_CACHING == 'true' && 'type=gha' ) || '' }}
-          cache-to: ${{ ( env.IS_CACHING == 'true' && 'type=gha,mode=max' ) || '' }}
-          no-cache: ${{ env.IS_CACHING != 'true' }}
-          sbom: true
-          provenance: mode=max
+          cache-from:  ${{ ( env.IS_CACHING == 'true' && 'type=gha' ) || '' }}
+          cache-to:    ${{ ( env.IS_CACHING == 'true' && 'type=gha,mode=max' ) || '' }}
+          no-cache:    ${{ env.IS_CACHING != 'true' }}
+          sbom:        true
+          provenance:  mode=max


### PR DESCRIPTION
This is the 1st of 2 PRs to migrate to the new Docker registry, where we have more control over the images and are able to manage them.
The new registry is https://hub.docker.com/u/photoview
