### PR TITLE
Fix the build script.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 env:
   IS_PUSHING_IMAGES: ${{ github.event_name != 'pull_request' && github.repository == 'photoview/photoview' }}
   # IS_PUSHING_IMAGES: true # Switch on when pushing images with forked repos.
-  DOCKER_REGISTRY: ${{ (github.repository == 'photoview/photoview' && '') || 'ghcr.io/' }}
+  DOCKER_REGISTRY: ${{ (github.repository != 'photoview/photoview' && 'ghcr.io/') || '' }}
   DOCKER_USERNAME: viktorstrate
   DOCKER_IMAGE: ${{ (github.repository == 'photoview/photoview' && 'viktorstrate/photoview') || github.repository }}
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
The build script failed with the new script.

The script has:

```
  DOCKER_REGISTRY: ${{ (github.repository == 'photoview/photoview' && '') || 'ghcr.io/' }}
  DOCKER_IMAGE: ${{ (github.repository == 'photoview/photoview' && 'viktorstrate/photoview') || github.repository }}
```

With input:

```
repository: photoview/photoview
```

The env expanded as:

```
DOCKER_REGISTRY: ghcr.io/
DOCKER_IMAGE: viktorstrate/photoview
```

I don't know why `DOCKER_REGISTRY` is generated from else branch while `DOCKER_IMAGE` is generated from then branch.

I'll try revert branches. But I can't verify if it works in a PR.