### PR TITLE
Fix scheduled docker build for the latest tagged commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-tags: 'true'
+          fetch-depth: 0
 
       - name: Prepare the Matrix
         id: prepare_matrix
@@ -37,13 +38,17 @@ jobs:
           case ${{ github.event_name }} in
             pull_request)
               echo 'tags=[{"tag": "", "ref": "${{ github.ref }}"}]' >> $GITHUB_OUTPUT
+              echo ***
+              git fetch --all
+              echo ***
+              git describe --tags --abbrev=0 --always
               ;;
             push)
               echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' >> $GITHUB_OUTPUT
               ;;
             schedule)
               git fetch --all
-              TAG=$(git describe --tags --abbrev=0 || exit 0)
+              TAG=$(git describe --tags --abbrev=0 --always || exit 0)
               if [ -z "$TAG" ]; then
                 echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' >> $GITHUB_OUTPUT
               else


### PR DESCRIPTION
Now scheduled runs for the Build workflow run only for the latest commit in the `master`. This fix is to make it catch the latest tag and run also for it.