### PR TITLE
ImageMagick: Remove deprecated `convert` and add required `-auto-orient` flags

### DIFF
--- a/api/scanner/media_encoding/executable_worker/magick_cli.go
+++ b/api/scanner/media_encoding/executable_worker/magick_cli.go
@@ -44,8 +44,8 @@ func (cli *MagickCli) IsInstalled() bool {
 
 func (cli *MagickCli) EncodeJpeg(inputPath string, outputPath string, jpegQuality int) error {
 	args := []string{
-		"convert",
 		inputPath,
+		"-auto-orient",
 		"-quality", fmt.Sprintf("%d", jpegQuality),
 		outputPath,
 	}


### PR DESCRIPTION
Fixes #1115 by adding the required `-auto-orient` CMD flag to the ImageMagick command.
Details are in the https://github.com/ImageMagick/ImageMagick/issues/5183

Also, I removed the `convert` option from the command, as ImageMagick returns this warning:
`WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"`