### PR TITLE
Update Language Label for Polish in Language Preferences

### DIFF
--- a/ui/src/Pages/SettingsPage/UserPreferences.tsx
+++ b/ui/src/Pages/SettingsPage/UserPreferences.tsx
@@ -25,7 +25,7 @@ const languagePreferences = [
   { key: 3, label: 'Svenska', flag: 'se', value: LanguageTranslation.Swedish },
   { key: 4, label: 'Dansk', flag: 'dk', value: LanguageTranslation.Danish },
   { key: 5, label: 'Español', flag: 'es', value: LanguageTranslation.Spanish },
-  { key: 6, label: 'polski', flag: 'pl', value: LanguageTranslation.Polish },
+  { key: 6, label: 'Polski', flag: 'pl', value: LanguageTranslation.Polish },
   { key: 7, label: 'Italiano', flag: 'it', value: LanguageTranslation.Italian },
   { key: 8, label: 'Deutsch', flag: 'de', value: LanguageTranslation.German },
   { key: 9, label: 'Русский', flag: 'ru', value: LanguageTranslation.Russian },


### PR DESCRIPTION
This PR updates the language label for Polish from `"polski"` to `"Polski"` in the `languagePreferences` array.

### Reason for Change
In order to maintain consistency with other language labels in the app, which all use capitalization (e.g., `"English"`, `"Deutsch"`, `"Français"`), the Polish label was updated to `"Polski"`. Using an uppercase first letter aligns with UI conventions and enhances readability. This minor change provides a more polished and professional appearance for users selecting languages.
