### PR TITLE
Fix the config builder job for scheduled docker build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,18 +37,15 @@ jobs:
         run: |
           case ${{ github.event_name }} in
             pull_request)
-              echo Event is ${{ github.event_name }}
+              echo Event is '${{ github.event_name }}'
               echo 'tags=[{"tag": "", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
-              git fetch --all
-              TAG=$(git describe --tags --abbrev=0 --always || exit 0)
-              echo tags-debug=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}, {"tag": "$TAG", "ref": "$(git show-ref --tags -d | grep "/$TAG$" | cut -d ' ' -f 2)"}] | tee -a $GITHUB_OUTPUT
               ;;
             push)
-              echo Event is ${{ github.event_name }}
+              echo Event is '${{ github.event_name }}'
               echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
               ;;
             schedule)
-              echo Event is ${{ github.event_name }}
+              echo Event is '${{ github.event_name }}'
               git fetch --all
               TAG=$(git describe --tags --abbrev=0 --always || exit 0)
               echo TAG = $TAG

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,23 +37,28 @@ jobs:
         run: |
           case ${{ github.event_name }} in
             pull_request)
-              echo 'tags=[{"tag": "", "ref": "${{ github.ref }}"}]' >> $GITHUB_OUTPUT
+              echo Event is ${{ github.event_name }}
+              echo 'tags=[{"tag": "", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
+              echo tags-debug=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}, {"tag": "$TAG", "ref": "$(git show-ref --tags -d | grep "/$TAG$" | cut -d ' ' -f 2)"}] | tee -a $GITHUB_OUTPUT
               ;;
             push)
-              echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' >> $GITHUB_OUTPUT
+              echo Event is ${{ github.event_name }}
+              echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
               ;;
             schedule)
+              echo Event is ${{ github.event_name }}
               git fetch --all
               TAG=$(git describe --tags --abbrev=0 --always || exit 0)
+              echo TAG = $TAG
               if [ -z "$TAG" ]; then
-                echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' >> $GITHUB_OUTPUT
+                echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
               else
-                echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}, {"tag": "$TAG", "ref": "$(git show-ref --tags -d | grep "/$TAG$" | cut -d ' ' -f 2)"}]' >> $GITHUB_OUTPUT
+                echo tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}, {"tag": "$TAG", "ref": "$(git show-ref --tags -d | grep "/$TAG$" | cut -d ' ' -f 2)"}] | tee -a $GITHUB_OUTPUT
               fi
               ;;
             *)
               echo "Run for '${{ github.event_name }}' is not expected"
-              echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' >> $GITHUB_OUTPUT
+              echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
               ;;
           esac
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,8 @@ jobs:
             pull_request)
               echo Event is ${{ github.event_name }}
               echo 'tags=[{"tag": "", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
+              git fetch --all
+              TAG=$(git describe --tags --abbrev=0 --always || exit 0)
               echo tags-debug=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}, {"tag": "$TAG", "ref": "$(git show-ref --tags -d | grep "/$TAG$" | cut -d ' ' -f 2)"}] | tee -a $GITHUB_OUTPUT
               ;;
             push)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,20 +35,18 @@ jobs:
         id: prepare_matrix
         shell: bash
         run: |
+          echo Event is '${{ github.event_name }}'
           case ${{ github.event_name }} in
             pull_request)
-              echo Event is '${{ github.event_name }}'
               echo 'tags=[{"tag": "", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
               ;;
             push)
-              echo Event is '${{ github.event_name }}'
               echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
               ;;
             schedule)
-              echo Event is '${{ github.event_name }}'
               git fetch --all
               TAG=$(git describe --tags --abbrev=0 --always || exit 0)
-              echo TAG = $TAG
+              echo TAG is $TAG
               if [ -z "$TAG" ]; then
                 echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
               else


### PR DESCRIPTION
Currently, the config builder job doesn't resolve the variables and nested command but returns them as a literal:
https://github.com/photoview/photoview/actions/runs/11829623096/job/32987927490#step:3:197

This PR fixes this issue:
https://github.com/photoview/photoview/actions/runs/11841074295/job/32996436786?pr=1120#step:3:41
The 2nd object in the `tags-debug` JSON array