### PR TITLE
Bump codecov-action in Tests workflow from 4 to 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,7 @@ jobs:
         docker cp test:/app/api/coverage.txt ./api/
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       if: ${{ steps.test.conclusion == 'success' }}
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -117,7 +117,7 @@ jobs:
         docker cp test:/app/ui/coverage ./ui/
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       if: ${{ steps.test.conclusion == 'success' }}
       with:
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
... according to the Dependabot PR in the forked repo: https://github.com/kkovaletp/photoview/pull/204