### PR TITLE
Add `log` package for better logging level.

### DIFF
--- a/api/log/default.go
+++ b/api/log/default.go
@@ -1,0 +1,57 @@
+package log
+
+import (
+	"context"
+	"log/slog"
+)
+
+var defaultLogger *slog.Logger
+
+func init() {
+	defaultLogger = slog.Default()
+}
+
+// Debug calls [Logger.Debug] on the default logger.
+func Debug(msg string, args ...any) {
+	defaultLogger.Debug(msg, args...)
+}
+
+// DebugContext calls [Logger.DebugContext] on the default logger.
+func DebugContext(ctx context.Context, msg string, args ...any) {
+	defaultLogger.DebugContext(ctx, msg, args...)
+}
+
+// Info calls [Logger.Info] on the default logger.
+func Info(msg string, args ...any) {
+	defaultLogger.Info(msg, args...)
+}
+
+// InfoContext calls [Logger.InfoContext] on the default logger.
+func InfoContext(ctx context.Context, msg string, args ...any) {
+	defaultLogger.InfoContext(ctx, msg, args...)
+}
+
+// Warn calls [Logger.Warn] on the default logger.
+func Warn(msg string, args ...any) {
+	defaultLogger.Warn(msg, args...)
+}
+
+// WarnContext calls [Logger.WarnContext] on the default logger.
+func WarnContext(ctx context.Context, msg string, args ...any) {
+	defaultLogger.WarnContext(ctx, msg, args...)
+}
+
+// Error calls [Logger.Error] on the default logger.
+func Error(msg string, args ...any) {
+	defaultLogger.Error(msg, args...)
+}
+
+// ErrorContext calls [Logger.ErrorContext] on the default logger.
+func ErrorContext(ctx context.Context, msg string, args ...any) {
+	defaultLogger.ErrorContext(ctx, msg, args...)
+}
+
+// With calls [Logger.With] on the default logger.
+func With(args ...any) *slog.Logger {
+	return defaultLogger.With(args...)
+}

--- a/api/scanner/media_encoding/executable_worker/executable_worker.go
+++ b/api/scanner/media_encoding/executable_worker/executable_worker.go
@@ -18,7 +18,7 @@ func InitializeExecutableWorkers() {
 	Ffmpeg = newFfmpegCli()
 
 	if err := SetFfprobePath(); err != nil {
-		log.Error("ffprobe init fail.", "error", err)
+		log.Error("Init ffprobe fail.", "error", err)
 	}
 }
 
@@ -40,7 +40,7 @@ func SetFfprobePath() error {
 		return fmt.Errorf("Executable ffprobe(%q) not executable: %w", path, err)
 	}
 
-	log.Info("found ffprobe", "path", path, "version", strings.Split(string(version), "\n")[0])
+	log.Info("Found ffprobe", "path", path, "version", strings.Split(string(version), "\n")[0])
 	ffprobe.SetFFProbeBinPath(path)
 
 	return nil

--- a/api/scanner/media_encoding/executable_worker/executable_worker.go
+++ b/api/scanner/media_encoding/executable_worker/executable_worker.go
@@ -1,20 +1,24 @@
 package executable_worker
 
 import (
+	"errors"
 	"fmt"
-	"log"
 	"os/exec"
 	"strings"
 
+	"github.com/photoview/photoview/api/log"
 	"gopkg.in/vansante/go-ffprobe.v2"
 )
+
+var ErrNoDependency = errors.New("dependency not found")
+var ErrDisabledFunction = errors.New("function disabled")
 
 func InitializeExecutableWorkers() {
 	Magick = newMagickCli()
 	Ffmpeg = newFfmpegCli()
 
 	if err := SetFfprobePath(); err != nil {
-		log.Println("ffprobe init fail:", err)
+		log.Error("ffprobe init fail.", "error", err)
 	}
 }
 
@@ -36,7 +40,7 @@ func SetFfprobePath() error {
 		return fmt.Errorf("Executable ffprobe(%q) not executable: %w", path, err)
 	}
 
-	log.Println("Found ffprobe:", path, "version:", strings.Split(string(version), "\n")[0])
+	log.Info("found ffprobe", "path", path, "version", strings.Split(string(version), "\n")[0])
 	ffprobe.SetFFProbeBinPath(path)
 
 	return nil

--- a/api/scanner/media_encoding/executable_worker/executable_worker.go
+++ b/api/scanner/media_encoding/executable_worker/executable_worker.go
@@ -13,7 +13,7 @@ import (
 var ErrNoDependency = errors.New("dependency not found")
 var ErrDisabledFunction = errors.New("function disabled")
 
-func InitializeExecutableWorkers() {
+func init() {
 	Magick = newMagickCli()
 	Ffmpeg = newFfmpegCli()
 

--- a/api/scanner/media_encoding/executable_worker/executable_worker_test.go
+++ b/api/scanner/media_encoding/executable_worker/executable_worker_test.go
@@ -1,45 +1,39 @@
-package executable_worker_test
+package executable_worker
 
 import (
-	"os"
 	"testing"
 
-	"github.com/photoview/photoview/api/scanner/media_encoding/executable_worker"
-	"github.com/photoview/photoview/api/test_utils"
+	"github.com/photoview/photoview/api/test_utils/test_env"
 )
-
-func TestMain(m *testing.M) {
-	os.Exit(test_utils.IntegrationTestRun(m))
-}
 
 const testdataBinPath = "./testdata/bin"
 
 func TestInitFfprobePath(t *testing.T) {
 	t.Run("PathFail", func(t *testing.T) {
-		err := executable_worker.SetFfprobePath()
+		err := SetFfprobePath()
 		if err == nil {
 			t.Fatalf("InitFfprobePath() returns nil, want an error")
 		}
 	})
 
 	t.Run("VersionFail", func(t *testing.T) {
-		donePath := test_utils.SetPathWithCurrent(testdataBinPath)
+		donePath := test_env.SetPathWithCurrent(testdataBinPath)
 		defer donePath()
 
-		doneEnv := test_utils.SetEnv("FAIL_WITH", "expect failure")
+		doneEnv := test_env.SetEnv("FAIL_WITH", "expect failure")
 		defer doneEnv()
 
-		err := executable_worker.SetFfprobePath()
+		err := SetFfprobePath()
 		if err == nil {
 			t.Fatalf("InitFfprobePath() returns nil, want an error")
 		}
 	})
 
 	t.Run("Succeed", func(t *testing.T) {
-		donePath := test_utils.SetPathWithCurrent(testdataBinPath)
+		donePath := test_env.SetPathWithCurrent(testdataBinPath)
 		defer donePath()
 
-		err := executable_worker.SetFfprobePath()
+		err := SetFfprobePath()
 		if err != nil {
 			t.Fatalf("InitFfprobePath() returns %v, want nil", err)
 		}

--- a/api/scanner/media_encoding/executable_worker/ffmpeg_cli.go
+++ b/api/scanner/media_encoding/executable_worker/ffmpeg_cli.go
@@ -2,10 +2,10 @@ package executable_worker
 
 import (
 	"fmt"
-	"log"
 	"os/exec"
 	"strings"
 
+	"github.com/photoview/photoview/api/log"
 	"github.com/photoview/photoview/api/utils"
 	"gopkg.in/vansante/go-ffprobe.v2"
 )
@@ -25,19 +25,19 @@ type FfmpegCli struct {
 
 func newFfmpegCli() *FfmpegCli {
 	if utils.EnvDisableVideoEncoding.GetBool() {
-		log.Printf("Executable worker disabled (%s=%q): ffmpeg\n", utils.EnvDisableVideoEncoding.GetName(), utils.EnvDisableVideoEncoding.GetValue())
+		log.Warn("Executable ffmpeg worker disabled", utils.EnvDisableVideoEncoding.GetName(), utils.EnvDisableVideoEncoding.GetValue())
 		return nil
 	}
 
 	path, err := exec.LookPath("ffmpeg")
 	if err != nil {
-		log.Println("Executable worker not found: ffmpeg")
+		log.Error("Executable ffmpeg worker not found")
 		return nil
 	}
 
 	version, err := exec.Command(path, "-version").Output()
 	if err != nil {
-		log.Printf("Error getting version of ffmpeg: %s\n", err)
+		log.Error("Executable ffmpeg worker getting version error", "error", err)
 		return nil
 	}
 
@@ -52,7 +52,7 @@ func newFfmpegCli() *FfmpegCli {
 		}
 	}
 
-	log.Printf("Found executable worker: ffmpeg (%s) with codec %q\n", strings.Split(string(version), "\n")[0], codec)
+	log.Info("Found executable worker: ffmpeg", "version", strings.Split(string(version), "\n")[0], "codec", codec)
 
 	return &FfmpegCli{
 		path:       path,
@@ -60,31 +60,46 @@ func newFfmpegCli() *FfmpegCli {
 	}
 }
 
-func (worker *FfmpegCli) IsInstalled() bool {
-	return worker != nil
+func (cli *FfmpegCli) IsInstalled() bool {
+	return cli != nil
 }
 
-func (worker *FfmpegCli) EncodeMp4(inputPath string, outputPath string) error {
+func (cli *FfmpegCli) EncodeMp4(inputPath string, outputPath string) error {
+	if cli == nil {
+		err := ErrNoDependency
+		if utils.EnvDisableVideoEncoding.GetBool() {
+			err = ErrDisabledFunction
+		}
+		return fmt.Errorf("encoding video %q error: ffmpeg: %w", inputPath, err)
+	}
+
 	args := []string{
 		"-i",
 		inputPath,
-		"-vcodec", worker.videoCodec,
+		"-vcodec", cli.videoCodec,
 		"-acodec", "aac",
 		"-vf", "scale='min(1080,iw)':'min(1080,ih)':force_original_aspect_ratio=decrease:force_divisible_by=2",
 		"-movflags", "+faststart+use_metadata_tags",
 		outputPath,
 	}
 
-	cmd := exec.Command(worker.path, args...)
+	cmd := exec.Command(cli.path, args...)
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("encoding video with %q %v error: %w", worker.path, args, err)
+		return fmt.Errorf("encoding video with %q %v error: %w", cli.path, args, err)
 	}
 
 	return nil
 }
 
-func (worker *FfmpegCli) EncodeVideoThumbnail(inputPath string, outputPath string, probeData *ffprobe.ProbeData) error {
+func (cli *FfmpegCli) EncodeVideoThumbnail(inputPath string, outputPath string, probeData *ffprobe.ProbeData) error {
+	if cli == nil {
+		err := ErrNoDependency
+		if utils.EnvDisableVideoEncoding.GetBool() {
+			err = ErrDisabledFunction
+		}
+		return fmt.Errorf("encoding video thumbnail %q error: ffmpeg: %w", inputPath, err)
+	}
 
 	thumbnailOffsetSeconds := fmt.Sprintf("%.f", probeData.Format.DurationSeconds*0.25)
 
@@ -98,10 +113,10 @@ func (worker *FfmpegCli) EncodeVideoThumbnail(inputPath string, outputPath strin
 		outputPath,
 	}
 
-	cmd := exec.Command(worker.path, args...)
+	cmd := exec.Command(cli.path, args...)
 
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("encoding video thumbnail with %q %v error: %w", worker.path, args, err)
+		return fmt.Errorf("encoding video thumbnail with %q %v error: %w", cli.path, args, err)
 	}
 
 	return nil

--- a/api/scanner/media_encoding/executable_worker/ffmpeg_cli_test.go
+++ b/api/scanner/media_encoding/executable_worker/ffmpeg_cli_test.go
@@ -14,7 +14,7 @@ func TestFfmpegNotExist(t *testing.T) {
 	done := test_env.SetPathWithCurrent()
 	defer done()
 
-	InitializeExecutableWorkers()
+	Ffmpeg = newFfmpegCli()
 
 	if Ffmpeg.IsInstalled() {
 		t.Error("Ffmpeg should not be installed, but is found:", Ffmpeg)
@@ -36,7 +36,7 @@ func TestFfmpegIgnore(t *testing.T) {
 	doneEnv := test_env.SetEnv("PHOTOVIEW_DISABLE_VIDEO_ENCODING", "true")
 	defer doneEnv()
 
-	InitializeExecutableWorkers()
+	Ffmpeg = newFfmpegCli()
 
 	if Ffmpeg.IsInstalled() {
 		t.Error("Ffmpeg should be ignored (as it is disabled), but is initialized:", Ffmpeg)
@@ -55,7 +55,7 @@ func TestFfmpeg(t *testing.T) {
 	done := test_env.SetPathWithCurrent(testdataBinPath)
 	defer done()
 
-	InitializeExecutableWorkers()
+	Ffmpeg = newFfmpegCli()
 
 	if !Ffmpeg.IsInstalled() {
 		t.Fatal("Ffmpeg should be installed")
@@ -114,7 +114,7 @@ func TestFfmpegWithHWAcc(t *testing.T) {
 	donePath := test_env.SetPathWithCurrent(testdataBinPath)
 	defer donePath()
 
-	InitializeExecutableWorkers()
+	Ffmpeg = newFfmpegCli()
 
 	doneEnv := test_env.SetEnv("FAIL_WITH", "expect failure")
 	defer doneEnv()
@@ -135,7 +135,7 @@ func TestFfmpegWithCustomCOdec(t *testing.T) {
 	donePath := test_env.SetPathWithCurrent(testdataBinPath)
 	defer donePath()
 
-	InitializeExecutableWorkers()
+	Ffmpeg = newFfmpegCli()
 
 	doneEnv := test_env.SetEnv("FAIL_WITH", "expect failure")
 	defer doneEnv()

--- a/api/scanner/media_encoding/executable_worker/ffmpeg_cli_test.go
+++ b/api/scanner/media_encoding/executable_worker/ffmpeg_cli_test.go
@@ -16,6 +16,36 @@ func TestFfmpegNotExist(t *testing.T) {
 
 	Ffmpeg = newFfmpegCli()
 
+	if got, want := Ffmpeg.err, ErrNoDependency; got != want {
+		t.Errorf("Ffmpeg.err = %v, want: %v", got, want)
+	}
+
+	if Ffmpeg.IsInstalled() {
+		t.Error("Ffmpeg should not be installed, but is found:", Ffmpeg)
+	}
+
+	if got, want := Ffmpeg.EncodeMp4("input", "output"), ErrNoDependency; !errors.Is(got, want) {
+		t.Errorf("Ffmpge.EncodeMp4() = %v, want: %v", got, want)
+	}
+
+	if got, want := Ffmpeg.EncodeVideoThumbnail("input", "output", nil), ErrNoDependency; !errors.Is(got, want) {
+		t.Errorf("Ffmpge.EncodeMp4() = %v, want: %v", got, want)
+	}
+}
+
+func TestFfmpegVersionFail(t *testing.T) {
+	donePath := test_env.SetPathWithCurrent(testdataBinPath)
+	defer donePath()
+
+	doneEnv := test_env.SetEnv("FAIL_WITH", "expect failure")
+	defer doneEnv()
+
+	Ffmpeg = newFfmpegCli()
+
+	if got, want := Ffmpeg.err, ErrNoDependency; got != want {
+		t.Errorf("Ffmpeg.err = %v, want: %v", got, want)
+	}
+
 	if Ffmpeg.IsInstalled() {
 		t.Error("Ffmpeg should not be installed, but is found:", Ffmpeg)
 	}
@@ -37,6 +67,10 @@ func TestFfmpegIgnore(t *testing.T) {
 	defer doneEnv()
 
 	Ffmpeg = newFfmpegCli()
+
+	if got, want := Ffmpeg.err, ErrDisabledFunction; got != want {
+		t.Errorf("Ffmpeg.err = %v, want: %v", got, want)
+	}
 
 	if Ffmpeg.IsInstalled() {
 		t.Error("Ffmpeg should be ignored (as it is disabled), but is initialized:", Ffmpeg)

--- a/api/scanner/media_encoding/executable_worker/ffmpeg_cli_test.go
+++ b/api/scanner/media_encoding/executable_worker/ffmpeg_cli_test.go
@@ -1,55 +1,71 @@
-package executable_worker_test
+package executable_worker
 
 import (
+	"errors"
 	"regexp"
 	"testing"
 
-	"github.com/photoview/photoview/api/scanner/media_encoding/executable_worker"
-	"github.com/photoview/photoview/api/test_utils"
+	"github.com/photoview/photoview/api/test_utils/test_env"
 	"github.com/photoview/photoview/api/utils"
 	"gopkg.in/vansante/go-ffprobe.v2"
 )
 
 func TestFfmpegNotExist(t *testing.T) {
-	done := test_utils.SetPathWithCurrent()
+	done := test_env.SetPathWithCurrent()
 	defer done()
 
-	executable_worker.InitializeExecutableWorkers()
+	InitializeExecutableWorkers()
 
-	if executable_worker.Ffmpeg.IsInstalled() {
-		t.Error("Ffmpeg should not be installed, but is found:", executable_worker.Ffmpeg)
+	if Ffmpeg.IsInstalled() {
+		t.Error("Ffmpeg should not be installed, but is found:", Ffmpeg)
+	}
+
+	if got, want := Ffmpeg.EncodeMp4("input", "output"), ErrNoDependency; !errors.Is(got, want) {
+		t.Errorf("Ffmpge.EncodeMp4() = %v, want: %v", got, want)
+	}
+
+	if got, want := Ffmpeg.EncodeVideoThumbnail("input", "output", nil), ErrNoDependency; !errors.Is(got, want) {
+		t.Errorf("Ffmpge.EncodeMp4() = %v, want: %v", got, want)
 	}
 }
 
 func TestFfmpegIgnore(t *testing.T) {
-	donePath := test_utils.SetPathWithCurrent(testdataBinPath)
+	donePath := test_env.SetPathWithCurrent(testdataBinPath)
 	defer donePath()
 
-	doneEnv := test_utils.SetEnv("PHOTOVIEW_DISABLE_VIDEO_ENCODING", "true")
+	doneEnv := test_env.SetEnv("PHOTOVIEW_DISABLE_VIDEO_ENCODING", "true")
 	defer doneEnv()
 
-	executable_worker.InitializeExecutableWorkers()
+	InitializeExecutableWorkers()
 
-	if executable_worker.Ffmpeg.IsInstalled() {
-		t.Error("Ffmpeg should be ignored (as it is disabled), but is initialized:", executable_worker.Ffmpeg)
+	if Ffmpeg.IsInstalled() {
+		t.Error("Ffmpeg should be ignored (as it is disabled), but is initialized:", Ffmpeg)
+	}
+
+	if got, want := Ffmpeg.EncodeMp4("input", "output"), ErrDisabledFunction; !errors.Is(got, want) {
+		t.Errorf("Ffmpge.EncodeMp4() = %v, want: %v", got, want)
+	}
+
+	if got, want := Ffmpeg.EncodeVideoThumbnail("input", "output", nil), ErrDisabledFunction; !errors.Is(got, want) {
+		t.Errorf("Ffmpge.EncodeMp4() = %v, want: %v", got, want)
 	}
 }
 
 func TestFfmpeg(t *testing.T) {
-	done := test_utils.SetPathWithCurrent(testdataBinPath)
+	done := test_env.SetPathWithCurrent(testdataBinPath)
 	defer done()
 
-	executable_worker.InitializeExecutableWorkers()
+	InitializeExecutableWorkers()
 
-	if !executable_worker.Ffmpeg.IsInstalled() {
+	if !Ffmpeg.IsInstalled() {
 		t.Fatal("Ffmpeg should be installed")
 	}
 
 	t.Run("EncodeMp4Failed", func(t *testing.T) {
-		doneEnv := test_utils.SetEnv("FAIL_WITH", "expect failure")
+		doneEnv := test_env.SetEnv("FAIL_WITH", "expect failure")
 		defer doneEnv()
 
-		err := executable_worker.Ffmpeg.EncodeMp4("input", "output")
+		err := Ffmpeg.EncodeMp4("input", "output")
 		if err == nil {
 			t.Fatalf("Ffmpeg.EncodeMp4(...) = nil, should be an error.")
 		}
@@ -59,7 +75,7 @@ func TestFfmpeg(t *testing.T) {
 	})
 
 	t.Run("EncodeMp4Succeeded", func(t *testing.T) {
-		err := executable_worker.Ffmpeg.EncodeMp4("input", "output")
+		err := Ffmpeg.EncodeMp4("input", "output")
 		if err != nil {
 			t.Fatalf("Ffmpeg.EncodeMp4(...) = %v, should be nil.", err)
 		}
@@ -71,10 +87,10 @@ func TestFfmpeg(t *testing.T) {
 		},
 	}
 	t.Run("EncodeVideoThumbnailMp4Failed", func(t *testing.T) {
-		doneEnv := test_utils.SetEnv("FAIL_WITH", "expect failure")
+		doneEnv := test_env.SetEnv("FAIL_WITH", "expect failure")
 		defer doneEnv()
 
-		err := executable_worker.Ffmpeg.EncodeVideoThumbnail("input", "output", probeData)
+		err := Ffmpeg.EncodeVideoThumbnail("input", "output", probeData)
 		if err == nil {
 			t.Fatalf("Ffmpeg.EncodeVideoThumbnail(...) = nil, should be an error.")
 		}
@@ -84,7 +100,7 @@ func TestFfmpeg(t *testing.T) {
 	})
 
 	t.Run("EncodeVideoThumbnailSucceeded", func(t *testing.T) {
-		err := executable_worker.Ffmpeg.EncodeVideoThumbnail("input", "output", probeData)
+		err := Ffmpeg.EncodeVideoThumbnail("input", "output", probeData)
 		if err != nil {
 			t.Fatalf("Ffmpeg.EncodeVideoThumbnail(...) = %v, should be nil.", err)
 		}
@@ -92,18 +108,18 @@ func TestFfmpeg(t *testing.T) {
 }
 
 func TestFfmpegWithHWAcc(t *testing.T) {
-	doneCodec := test_utils.SetEnv(utils.EnvVideoHardwareAcceleration.GetName(), "qsv")
+	doneCodec := test_env.SetEnv(utils.EnvVideoHardwareAcceleration.GetName(), "qsv")
 	defer doneCodec()
 
-	donePath := test_utils.SetPathWithCurrent(testdataBinPath)
+	donePath := test_env.SetPathWithCurrent(testdataBinPath)
 	defer donePath()
 
-	executable_worker.InitializeExecutableWorkers()
+	InitializeExecutableWorkers()
 
-	doneEnv := test_utils.SetEnv("FAIL_WITH", "expect failure")
+	doneEnv := test_env.SetEnv("FAIL_WITH", "expect failure")
 	defer doneEnv()
 
-	err := executable_worker.Ffmpeg.EncodeMp4("input", "output")
+	err := Ffmpeg.EncodeMp4("input", "output")
 	if err == nil {
 		t.Fatalf("Ffmpeg.EncodeMp4(...) = nil, should be an error.")
 	}
@@ -113,18 +129,18 @@ func TestFfmpegWithHWAcc(t *testing.T) {
 }
 
 func TestFfmpegWithCustomCOdec(t *testing.T) {
-	doneCodec := test_utils.SetEnv(utils.EnvVideoHardwareAcceleration.GetName(), "_custom")
+	doneCodec := test_env.SetEnv(utils.EnvVideoHardwareAcceleration.GetName(), "_custom")
 	defer doneCodec()
 
-	donePath := test_utils.SetPathWithCurrent(testdataBinPath)
+	donePath := test_env.SetPathWithCurrent(testdataBinPath)
 	defer donePath()
 
-	executable_worker.InitializeExecutableWorkers()
+	InitializeExecutableWorkers()
 
-	doneEnv := test_utils.SetEnv("FAIL_WITH", "expect failure")
+	doneEnv := test_env.SetEnv("FAIL_WITH", "expect failure")
 	defer doneEnv()
 
-	err := executable_worker.Ffmpeg.EncodeMp4("input", "output")
+	err := Ffmpeg.EncodeMp4("input", "output")
 	if err == nil {
 		t.Fatalf("Ffmpeg.EncodeMp4(...) = nil, should be an error.")
 	}

--- a/api/scanner/media_encoding/executable_worker/magick_cli.go
+++ b/api/scanner/media_encoding/executable_worker/magick_cli.go
@@ -11,24 +11,31 @@ import (
 
 type MagickCli struct {
 	path string
+	err  error
 }
 
 func newMagickCli() *MagickCli {
 	if utils.EnvDisableRawProcessing.GetBool() {
 		log.Warn("Executable magick worker disabled", utils.EnvDisableRawProcessing.GetName(), utils.EnvDisableRawProcessing.GetValue())
-		return nil
+		return &MagickCli{
+			err: ErrDisabledFunction,
+		}
 	}
 
 	path, err := exec.LookPath("magick")
 	if err != nil {
 		log.Error("Executable magick worker not found")
-		return nil
+		return &MagickCli{
+			err: ErrNoDependency,
+		}
 	}
 
 	version, err := exec.Command(path, "-version").Output()
 	if err != nil {
 		log.Error("Executable magick worker get version error", "error", err)
-		return nil
+		return &MagickCli{
+			err: ErrNoDependency,
+		}
 	}
 
 	log.Info("Found magick executable worker", "version", strings.Split(string(version), "\n")[0])
@@ -39,16 +46,12 @@ func newMagickCli() *MagickCli {
 }
 
 func (cli *MagickCli) IsInstalled() bool {
-	return cli != nil
+	return cli.err == nil
 }
 
 func (cli *MagickCli) EncodeJpeg(inputPath string, outputPath string, jpegQuality int) error {
-	if cli == nil {
-		err := ErrNoDependency
-		if utils.EnvDisableRawProcessing.GetBool() {
-			err = ErrDisabledFunction
-		}
-		return fmt.Errorf("encoding jpeg %q error: magick: %w", inputPath, err)
+	if cli.err != nil {
+		return fmt.Errorf("encoding jpeg %q error: magick: %w", inputPath, cli.err)
 	}
 
 	args := []string{

--- a/api/scanner/media_encoding/executable_worker/magick_cli_test.go
+++ b/api/scanner/media_encoding/executable_worker/magick_cli_test.go
@@ -1,49 +1,57 @@
-package executable_worker_test
+package executable_worker
 
 import (
+	"errors"
 	"regexp"
 	"testing"
 
-	"github.com/photoview/photoview/api/scanner/media_encoding/executable_worker"
-	"github.com/photoview/photoview/api/test_utils"
+	"github.com/photoview/photoview/api/test_utils/test_env"
 )
 
 func TestMagickCliNotExist(t *testing.T) {
-	done := test_utils.SetPathWithCurrent()
+	done := test_env.SetPathWithCurrent()
 	defer done()
 
-	executable_worker.InitializeExecutableWorkers()
-	if executable_worker.Magick.IsInstalled() {
-		t.Error("MagickCli should not be installed, but is found:", executable_worker.Magick)
+	InitializeExecutableWorkers()
+	if Magick.IsInstalled() {
+		t.Error("MagickCli should not be installed, but is found:", Magick)
+	}
+
+	if got, want := Magick.EncodeJpeg("input", "output", 70), ErrNoDependency; !errors.Is(got, want) {
+		t.Errorf("Magick.EncodeJpeg() = %v, want: %v", got, want)
 	}
 }
 
 func TestMagickCliIgnore(t *testing.T) {
-	donePath := test_utils.SetPathWithCurrent(testdataBinPath)
+	donePath := test_env.SetPathWithCurrent(testdataBinPath)
 	defer donePath()
 
-	doneDisableRaw := test_utils.SetEnv("PHOTOVIEW_DISABLE_RAW_PROCESSING", "true")
+	doneDisableRaw := test_env.SetEnv("PHOTOVIEW_DISABLE_RAW_PROCESSING", "true")
 	defer doneDisableRaw()
 
-	executable_worker.InitializeExecutableWorkers()
-	if executable_worker.Magick.IsInstalled() {
-		t.Error("MagickCli should not be installed, but is found:", executable_worker.Magick)
+	InitializeExecutableWorkers()
+	if Magick.IsInstalled() {
+		t.Error("MagickCli should not be installed, but is found:", Magick)
+	}
+
+	if got, want := Magick.EncodeJpeg("input", "output", 70), ErrDisabledFunction; !errors.Is(got, want) {
+		t.Errorf("Magick.EncodeJpeg() = %v, want: %v", got, want)
 	}
 }
 
 func TestMagickCliFail(t *testing.T) {
-	donePath := test_utils.SetPathWithCurrent(testdataBinPath)
+	donePath := test_env.SetPathWithCurrent(testdataBinPath)
 	defer donePath()
 
-	executable_worker.InitializeExecutableWorkers()
-	if !executable_worker.Magick.IsInstalled() {
+	InitializeExecutableWorkers()
+	if !Magick.IsInstalled() {
 		t.Fatal("MagickCli should be installed")
 	}
 
-	done := test_utils.SetEnv("FAIL_WITH", "failure")
+	done := test_env.SetEnv("FAIL_WITH", "failure")
 	defer done()
 
-	err := executable_worker.Magick.EncodeJpeg("input", "output", 70)
+	err := Magick.EncodeJpeg("input", "output", 70)
 	if err == nil {
 		t.Fatalf(`MagickCli.EncodeJpeg(...) = nil, should be an error.`)
 	}
@@ -54,16 +62,16 @@ func TestMagickCliFail(t *testing.T) {
 }
 
 func TestMagickCliSucceed(t *testing.T) {
-	donePath := test_utils.SetPathWithCurrent(testdataBinPath)
+	donePath := test_env.SetPathWithCurrent(testdataBinPath)
 	defer donePath()
 
-	executable_worker.InitializeExecutableWorkers()
-	if !executable_worker.Magick.IsInstalled() {
+	InitializeExecutableWorkers()
+	if !Magick.IsInstalled() {
 		t.Fatal("MagickCli should be installed")
 	}
 
 	t.Run("Succeeded", func(t *testing.T) {
-		err := executable_worker.Magick.EncodeJpeg("input", "output", 70)
+		err := Magick.EncodeJpeg("input", "output", 70)
 		if err != nil {
 			t.Fatalf("MagickCli.EncodeJpeg(...) = %v, should be nil.", err)
 		}

--- a/api/scanner/media_encoding/executable_worker/magick_cli_test.go
+++ b/api/scanner/media_encoding/executable_worker/magick_cli_test.go
@@ -12,7 +12,8 @@ func TestMagickCliNotExist(t *testing.T) {
 	done := test_env.SetPathWithCurrent()
 	defer done()
 
-	InitializeExecutableWorkers()
+	Magick = newMagickCli()
+
 	if Magick.IsInstalled() {
 		t.Error("MagickCli should not be installed, but is found:", Magick)
 	}
@@ -29,7 +30,8 @@ func TestMagickCliIgnore(t *testing.T) {
 	doneDisableRaw := test_env.SetEnv("PHOTOVIEW_DISABLE_RAW_PROCESSING", "true")
 	defer doneDisableRaw()
 
-	InitializeExecutableWorkers()
+	Magick = newMagickCli()
+
 	if Magick.IsInstalled() {
 		t.Error("MagickCli should not be installed, but is found:", Magick)
 	}
@@ -43,7 +45,8 @@ func TestMagickCliFail(t *testing.T) {
 	donePath := test_env.SetPathWithCurrent(testdataBinPath)
 	defer donePath()
 
-	InitializeExecutableWorkers()
+	Magick = newMagickCli()
+
 	if !Magick.IsInstalled() {
 		t.Fatal("MagickCli should be installed")
 	}
@@ -65,7 +68,8 @@ func TestMagickCliSucceed(t *testing.T) {
 	donePath := test_env.SetPathWithCurrent(testdataBinPath)
 	defer donePath()
 
-	InitializeExecutableWorkers()
+	Magick = newMagickCli()
+
 	if !Magick.IsInstalled() {
 		t.Fatal("MagickCli should be installed")
 	}

--- a/api/scanner/media_encoding/executable_worker/magick_cli_test.go
+++ b/api/scanner/media_encoding/executable_worker/magick_cli_test.go
@@ -14,6 +14,10 @@ func TestMagickCliNotExist(t *testing.T) {
 
 	Magick = newMagickCli()
 
+	if got, want := Magick.err, ErrNoDependency; got != want {
+		t.Errorf("Magick.err = %v, want: %v", got, want)
+	}
+
 	if Magick.IsInstalled() {
 		t.Error("MagickCli should not be installed, but is found:", Magick)
 	}
@@ -32,11 +36,37 @@ func TestMagickCliIgnore(t *testing.T) {
 
 	Magick = newMagickCli()
 
+	if got, want := Magick.err, ErrDisabledFunction; got != want {
+		t.Errorf("Magick.err = %v, want: %v", got, want)
+	}
+
 	if Magick.IsInstalled() {
 		t.Error("MagickCli should not be installed, but is found:", Magick)
 	}
 
 	if got, want := Magick.EncodeJpeg("input", "output", 70), ErrDisabledFunction; !errors.Is(got, want) {
+		t.Errorf("Magick.EncodeJpeg() = %v, want: %v", got, want)
+	}
+}
+
+func TestMagickCliVersionFail(t *testing.T) {
+	donePath := test_env.SetPathWithCurrent(testdataBinPath)
+	defer donePath()
+
+	done := test_env.SetEnv("FAIL_WITH", "failure")
+	defer done()
+
+	Magick = newMagickCli()
+
+	if got, want := Magick.err, ErrNoDependency; got != want {
+		t.Errorf("Magick.err = %v, want: %v", got, want)
+	}
+
+	if Magick.IsInstalled() {
+		t.Error("MagickCli should not be installed, but is found:", Magick)
+	}
+
+	if got, want := Magick.EncodeJpeg("input", "output", 70), ErrNoDependency; !errors.Is(got, want) {
 		t.Errorf("Magick.EncodeJpeg() = %v, want: %v", got, want)
 	}
 }

--- a/api/scanner/media_encoding/executable_worker/testdata/bin/magick
+++ b/api/scanner/media_encoding/executable_worker/testdata/bin/magick
@@ -6,7 +6,6 @@ set -eu
 if [ "$1" = "-version" ]
 then
   echo magick: version fake
-  exit 0
 fi
 
 if [ "${FAIL_WITH}" != "" ]

--- a/api/scanner/scanner_tasks/processing_tasks/counterpart_files_task_test.go
+++ b/api/scanner/scanner_tasks/processing_tasks/counterpart_files_task_test.go
@@ -1,4 +1,4 @@
-package processing_tasks_test
+package processing_tasks
 
 import (
 	"context"
@@ -8,8 +8,7 @@ import (
 	"testing"
 
 	"github.com/photoview/photoview/api/scanner/scanner_task"
-	"github.com/photoview/photoview/api/scanner/scanner_tasks/processing_tasks"
-	"github.com/photoview/photoview/api/test_utils"
+	"github.com/photoview/photoview/api/test_utils/test_env"
 	"github.com/photoview/photoview/api/utils"
 )
 
@@ -70,11 +69,11 @@ func TestCounterpartFilesTaskMediaFound(t *testing.T) {
 		},
 	}
 
-	mediaPath := test_utils.PathFromAPIRoot("scanner/test_data/fake_media")
+	mediaPath := test_env.PathFromAPIRoot("scanner/test_data/fake_media")
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			done := test_utils.SetEnv(string(utils.EnvDisableRawProcessing), fmt.Sprintf("%v", tc.disableRawProcessing))
+			done := test_env.SetEnv(string(utils.EnvDisableRawProcessing), fmt.Sprintf("%v", tc.disableRawProcessing))
 			defer done()
 
 			ctx := scanner_task.NewTaskContext(context.Background(), nil, nil, nil)
@@ -85,7 +84,7 @@ func TestCounterpartFilesTaskMediaFound(t *testing.T) {
 				t.Fatalf("Stat(%q) error: %v", fname, err)
 			}
 
-			var task processing_tasks.CounterpartFilesTask
+			var task CounterpartFilesTask
 			got, err := task.MediaFound(ctx, fi, fname)
 			if err != nil {
 				t.Fatalf("task.MediaFound(ctx, %q) error: %v", fname, err)

--- a/api/server.go
+++ b/api/server.go
@@ -17,7 +17,6 @@ import (
 	"github.com/photoview/photoview/api/routes"
 	"github.com/photoview/photoview/api/scanner/exif"
 	"github.com/photoview/photoview/api/scanner/face_detection"
-	"github.com/photoview/photoview/api/scanner/media_encoding/executable_worker"
 	"github.com/photoview/photoview/api/scanner/periodic_scanner"
 	"github.com/photoview/photoview/api/scanner/scanner_queue"
 	"github.com/photoview/photoview/api/server"
@@ -53,8 +52,6 @@ func main() {
 	if err := periodic_scanner.InitializePeriodicScanner(db); err != nil {
 		log.Panicf("Could not initialize periodic scanner: %s", err)
 	}
-
-	executable_worker.InitializeExecutableWorkers()
 
 	exif.InitializeEXIFParser()
 

--- a/api/test_utils/test_env/env.go
+++ b/api/test_utils/test_env/env.go
@@ -1,11 +1,23 @@
-package test_utils
+package test_env
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 )
+
+type integration_options struct {
+	Database   *bool
+	Filesystem *bool
+}
+
+// Fake flags to be compatible with current test command.
+var integration_flags integration_options = integration_options{
+	Database:   flag.Bool("database", false, "run database integration tests"),
+	Filesystem: flag.Bool("filesystem", false, "run filesystem integration tests"),
+}
 
 func SetPathWithCurrent(paths ...string) func() {
 	_, file, _, ok := runtime.Caller(1)
@@ -45,5 +57,5 @@ func PathFromAPIRoot(rootRelatedPath string) string {
 
 	base := filepath.Dir(file)
 
-	return filepath.Join(base, "..", rootRelatedPath)
+	return filepath.Join(base, "../..", rootRelatedPath)
 }

--- a/api/test_utils/test_env/env_test.go
+++ b/api/test_utils/test_env/env_test.go
@@ -1,4 +1,4 @@
-package test_utils
+package test_env
 
 import (
 	"os"
@@ -20,7 +20,7 @@ func TestSetPathWithCurrent(t *testing.T) {
 	defer testDone()
 
 	path := os.Getenv("PATH")
-	if got, want := path, "api/test_utils/test"; !strings.HasSuffix(got, want) {
+	if got, want := path, "api/test_utils/test_env/test"; !strings.HasSuffix(got, want) {
 		t.Errorf("path = %q, want a suffix: %q", got, want)
 	}
 }


### PR DESCRIPTION
It's splitted from #1124.

We should use `log` package to do better logging (level, context). There is not much logic in `log` now. In the future, we could add more functions to this package.