### PR TITLE
Another fix for the scheduled image build workflow for tag case

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,10 @@ jobs:
           case ${{ github.event_name }} in
             pull_request)
               echo 'tags=[{"tag": "", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
+              git fetch --all
+              TAG=$(git describe --tags --abbrev=0 --always || exit 0)
+              echo TAG is $TAG
+              echo tags=[{'"'tag'"': '"'${{ github.ref_name }}'"', '"'ref'"': '"'${{ github.ref }}'"'}, {'"'tag'"': '"'${TAG#v}'"', '"'ref'"': '"'$(git show-ref --tags -d | grep "/$TAG$" | cut -d ' ' -f 2)'"'}] | tee -a $GITHUB_OUTPUT
               ;;
             push)
               echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
@@ -50,7 +54,7 @@ jobs:
               if [ -z "$TAG" ]; then
                 echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
               else
-                echo tags=[{'"'tag'"': '"'${{ github.ref_name }}'"', '"'ref'"': '"'${{ github.ref }}'"'}, {'"'tag'"': '"'$TAG'"', '"'ref'"': '"'$(git show-ref --tags -d | grep "/$TAG$" | cut -d ' ' -f 2)'"'}] | tee -a $GITHUB_OUTPUT
+                echo tags=[{'"'tag'"': '"'${{ github.ref_name }}'"', '"'ref'"': '"'${{ github.ref }}'"'}, {'"'tag'"': '"'${TAG#v}'"', '"'ref'"': '"'$(git show-ref --tags -d | grep "/$TAG$" | cut -d ' ' -f 2)'"'}] | tee -a $GITHUB_OUTPUT
               fi
               ;;
             *)
@@ -106,13 +110,20 @@ jobs:
           images: ${{ env.DOCKER_REGISTRY }}${{ env.DOCKER_IMAGE }}
           # Docker tags based on the following events/attributes
           tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
+            ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{version}}' || '' }}
+            ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
+            ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{major}}' || '' }}
+            ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'latest' || '' }}
+            ${{ github.event_name == 'schedule' && matrix.tags.tag == 'master' && 'type=ref,event=branch' || '' }}
+            ${{ github.event_name == 'schedule' && matrix.tags.tag == 'master' && 'type=sha' || '' }}
+            ${{ github.event_name != 'schedule' && 'type=ref,event=branch' || '' }}
+            ${{ github.event_name != 'schedule' && 'type=ref,event=pr' || '' }}
+            ${{ github.event_name != 'schedule' && 'type=semver,pattern={{version}}' || '' }}
+            ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
+            ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}' || '' }}
+            ${{ github.event_name != 'schedule' && 'type=sha' || '' }}
+        env:
+          GITHUB_REF: ${{ github.event_name == 'schedule' && matrix.tags.ref || github.ref }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,10 +110,14 @@ jobs:
           images: ${{ env.DOCKER_REGISTRY }}${{ env.DOCKER_IMAGE }}
           # Docker tags based on the following events/attributes
           tags: |
-            ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{version}}' || '' }}
-            ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
-            ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{major}}' || '' }}
-            ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'latest' || '' }}
+            # ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{version}}' || '' }}
+            # ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
+            # ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{major}}' || '' }}
+            # ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'latest' || '' }}
+            ${{ matrix.tags.tag == '2.4.0' && 'type=semver,pattern={{version}}' || '' }}
+            ${{ matrix.tags.tag == '2.4.0' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
+            ${{ matrix.tags.tag == '2.4.0' && 'type=semver,pattern={{major}}' || '' }}
+            ${{ matrix.tags.tag == '2.4.0' && 'latest' || '' }}
             ${{ github.event_name == 'schedule' && matrix.tags.tag == 'master' && 'type=ref,event=branch' || '' }}
             ${{ github.event_name == 'schedule' && matrix.tags.tag == 'master' && 'type=sha' || '' }}
             ${{ github.event_name != 'schedule' && 'type=ref,event=branch' || '' }}
@@ -123,7 +127,8 @@ jobs:
             ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}' || '' }}
             ${{ github.event_name != 'schedule' && 'type=sha' || '' }}
         env:
-          GITHUB_REF: ${{ github.event_name == 'schedule' && matrix.tags.ref || github.ref }}
+          # GITHUB_REF: ${{ github.event_name == 'schedule' && matrix.tags.ref || github.ref }}
+          GITHUB_REF: ${{ matrix.tags.tag == '2.4.0' && matrix.tags.ref || github.ref }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,7 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v5
         with:
+          context: "git"
           # list of Docker images to use as base name for tags
           images: ${{ env.DOCKER_REGISTRY }}${{ env.DOCKER_IMAGE }}
           # Docker tags based on the following events/attributes
@@ -120,12 +121,12 @@ jobs:
             ${{ matrix.tags.tag == '2.4.0' && 'latest' || '' }}
             ${{ github.event_name == 'schedule' && matrix.tags.tag == 'master' && 'type=ref,event=branch' || '' }}
             ${{ github.event_name == 'schedule' && matrix.tags.tag == 'master' && 'type=sha' || '' }}
-            ${{ github.event_name != 'schedule' && 'type=ref,event=branch' || '' }}
-            ${{ github.event_name != 'schedule' && 'type=ref,event=pr' || '' }}
-            ${{ github.event_name != 'schedule' && 'type=semver,pattern={{version}}' || '' }}
-            ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
-            ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}' || '' }}
-            ${{ github.event_name != 'schedule' && 'type=sha' || '' }}
+            # ${{ github.event_name != 'schedule' && 'type=ref,event=branch' || '' }}
+            # ${{ github.event_name != 'schedule' && 'type=ref,event=pr' || '' }}
+            # ${{ github.event_name != 'schedule' && 'type=semver,pattern={{version}}' || '' }}
+            # ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
+            # ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}' || '' }}
+            # ${{ github.event_name != 'schedule' && 'type=sha' || '' }}
         env:
           # GITHUB_REF: ${{ github.event_name == 'schedule' && matrix.tags.ref || github.ref }}
           GITHUB_REF: ${{ matrix.tags.tag == '2.4.0' && matrix.tags.ref || github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,11 +114,9 @@ jobs:
             # ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{version}}' || '' }}
             # ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
             # ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{major}}' || '' }}
-            # ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'latest' || '' }}
             ${{ matrix.tags.tag == '2.4.0' && 'type=semver,pattern={{version}}' || '' }}
             ${{ matrix.tags.tag == '2.4.0' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
             ${{ matrix.tags.tag == '2.4.0' && 'type=semver,pattern={{major}}' || '' }}
-            ${{ matrix.tags.tag == '2.4.0' && 'latest' || '' }}
             ${{ github.event_name == 'schedule' && matrix.tags.tag == 'master' && 'type=ref,event=branch' || '' }}
             ${{ github.event_name == 'schedule' && matrix.tags.tag == 'master' && 'type=sha' || '' }}
             # ${{ github.event_name != 'schedule' && 'type=ref,event=branch' || '' }}
@@ -127,9 +125,9 @@ jobs:
             # ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
             # ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}' || '' }}
             # ${{ github.event_name != 'schedule' && 'type=sha' || '' }}
-        env:
+        # env:
           # GITHUB_REF: ${{ github.event_name == 'schedule' && matrix.tags.ref || github.ref }}
-          GITHUB_REF: ${{ matrix.tags.tag == '2.4.0' && matrix.tags.ref || github.ref }}
+          # GITHUB_REF: ${{ matrix.tags.tag == '2.4.0' && matrix.tags.ref || github.ref }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -161,7 +159,7 @@ jobs:
       matrix:
         tags: ${{ fromJson(needs.prepare.outputs.tags) }}
     # Comment out when pushing images with forked repos.
-    if: ${{ github.event_name != 'pull_request' && github.repository == 'photoview/photoview' }}
+    # if: ${{ github.event_name != 'pull_request' && github.repository == 'photoview/photoview' }}
     steps:
       # Makes sure your .dockleignore file is available to the next step
       - name: Checkout ${{ matrix.tags.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,10 +39,6 @@ jobs:
           case ${{ github.event_name }} in
             pull_request)
               echo 'tags=[{"tag": "", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
-              git fetch --all
-              TAG=$(git describe --tags --abbrev=0 --always || exit 0)
-              echo TAG is $TAG
-              echo tags=[{'"'tag'"': '"'${{ github.ref_name }}'"', '"'ref'"': '"'${{ github.ref }}'"'}, {'"'tag'"': '"'${TAG#v}'"', '"'ref'"': '"'$(git show-ref --tags -d | grep "/$TAG$" | cut -d ' ' -f 2)'"'}] | tee -a $GITHUB_OUTPUT
               ;;
             push)
               echo 'tags=[{"tag": "${{ github.ref_name }}", "ref": "${{ github.ref }}"}]' | tee -a $GITHUB_OUTPUT
@@ -107,27 +103,19 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           context: "git"
-          # list of Docker images to use as base name for tags
           images: ${{ env.DOCKER_REGISTRY }}${{ env.DOCKER_IMAGE }}
-          # Docker tags based on the following events/attributes
           tags: |
-            # ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{version}}' || '' }}
-            # ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
-            # ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{major}}' || '' }}
-            ${{ matrix.tags.tag == '2.4.0' && 'type=semver,pattern={{version}}' || '' }}
-            ${{ matrix.tags.tag == '2.4.0' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
-            ${{ matrix.tags.tag == '2.4.0' && 'type=semver,pattern={{major}}' || '' }}
+            ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{version}}' || '' }}
+            ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
+            ${{ github.event_name == 'schedule' && matrix.tags.tag != 'master' && 'type=semver,pattern={{major}}' || '' }}
             ${{ github.event_name == 'schedule' && matrix.tags.tag == 'master' && 'type=ref,event=branch' || '' }}
             ${{ github.event_name == 'schedule' && matrix.tags.tag == 'master' && 'type=sha' || '' }}
-            # ${{ github.event_name != 'schedule' && 'type=ref,event=branch' || '' }}
-            # ${{ github.event_name != 'schedule' && 'type=ref,event=pr' || '' }}
-            # ${{ github.event_name != 'schedule' && 'type=semver,pattern={{version}}' || '' }}
-            # ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
-            # ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}' || '' }}
-            # ${{ github.event_name != 'schedule' && 'type=sha' || '' }}
-        # env:
-          # GITHUB_REF: ${{ github.event_name == 'schedule' && matrix.tags.ref || github.ref }}
-          # GITHUB_REF: ${{ matrix.tags.tag == '2.4.0' && matrix.tags.ref || github.ref }}
+            ${{ github.event_name != 'schedule' && 'type=ref,event=branch' || '' }}
+            ${{ github.event_name != 'schedule' && 'type=ref,event=pr' || '' }}
+            ${{ github.event_name != 'schedule' && 'type=semver,pattern={{version}}' || '' }}
+            ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}.{{minor}}' || '' }}
+            ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}' || '' }}
+            ${{ github.event_name != 'schedule' && 'type=sha' || '' }}
 
       - name: Build and push
         uses: docker/build-push-action@v6
@@ -159,7 +147,7 @@ jobs:
       matrix:
         tags: ${{ fromJson(needs.prepare.outputs.tags) }}
     # Comment out when pushing images with forked repos.
-    # if: ${{ github.event_name != 'pull_request' && github.repository == 'photoview/photoview' }}
+    if: ${{ github.event_name != 'pull_request' && github.repository == 'photoview/photoview' }}
     steps:
       # Makes sure your .dockleignore file is available to the next step
       - name: Checkout ${{ matrix.tags.ref }}


### PR DESCRIPTION
Currently, there are several issues with the scheduled build workflow for the tag case:
- incorrect ref detection by the `docker_meta` step
- incorrect tag name in the matrix
- incorrect tags creation by the `docker_meta` step for this case

Here is the example of the failed run: 
- Build image: https://github.com/photoview/photoview/actions/runs/12061541425/job/33639836920
- Analyze image: https://github.com/photoview/photoview/actions/runs/12061541425/job/33639837502

This PR tries to fix these issues:
- Build image: https://github.com/photoview/photoview/actions/runs/12097423701/job/33732791582?pr=1137#step:8:59
- Analyze image: https://github.com/photoview/photoview/actions/runs/12097423701/job/33733027358?pr=1137#step:4:73