### PR TITLE
Add support for external HTTP authentication

### DIFF
--- a/api/example.env
+++ b/api/example.env
@@ -37,3 +37,6 @@ PHOTOVIEW_DEVELOPMENT_MODE=1
 # Support `qsv`, `vaapi`, `nvenc`.
 # Only `qsv` is verified with `/dev/dri//dev/dri` devices.
 # PHOTOVIEW_VIDEO_HARDWARE_ACCELERATION=
+
+# Set an HTTP endpoint to use for user authentication
+#PHOTOVIEW_HTTP_USER_AUTH=http://localhost:8080

--- a/api/utils/environment_variables.go
+++ b/api/utils/environment_variables.go
@@ -15,6 +15,7 @@ const (
 	EnvUIPath                    EnvironmentVariable = "PHOTOVIEW_UI_PATH"
 	EnvMediaCachePath            EnvironmentVariable = "PHOTOVIEW_MEDIA_CACHE"
 	EnvFaceRecognitionModelsPath EnvironmentVariable = "PHOTOVIEW_FACE_RECOGNITION_MODELS_PATH"
+	EnvHTTPUserAuth              EnvironmentVariable = "PHOTOVIEW_HTTP_USER_AUTH"
 )
 
 // Network related


### PR DESCRIPTION
Allow administrators to delegate password checks to another HTTP server. This is useful when multiple services are offered to users (Photoview being one of them) and passwords are handled by a separate centralized authentication server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for external HTTP-based user authentication
	- Introduced a new configuration option for HTTP user authentication endpoint

- **Configuration**
	- Added `PHOTOVIEW_HTTP_USER_AUTH` environment variable to enable optional external authentication

<!-- end of auto-generated comment: release notes by coderabbit.ai -->