### PR TITLE
improved Thumbnail generation performance

### DIFF
--- a/api/graphql/models/album.go
+++ b/api/graphql/models/album.go
@@ -94,12 +94,12 @@ func (a *Album) Thumbnail(db *gorm.DB) (*Media, error) {
 		WITH RECURSIVE sub_albums AS (
 			SELECT id FROM albums WHERE id = ?
 			UNION ALL
-			SELECT child.id FROM albums AS child
-			INNER JOIN sub_albums ON child.parent_album_id = sub_albums.id
+			SELECT children.id FROM albums AS children
+			INNER JOIN sub_albums ON children.parent_album_id = sub_albums.id
 		)
-		SELECT m.* FROM media AS m
-		INNER JOIN media_urls AS mu ON mu.media_id = m.id
-		WHERE m.album_id IN (SELECT id FROM sub_albums)
+		SELECT * FROM media
+		INNER JOIN media_urls ON media_urls.media_id = media.id
+		WHERE media.album_id IN (SELECT id FROM sub_albums)
 		LIMIT 1
 	`
 

--- a/api/graphql/models/album.go
+++ b/api/graphql/models/album.go
@@ -94,8 +94,8 @@ func (a *Album) Thumbnail(db *gorm.DB) (*Media, error) {
 		WITH RECURSIVE sub_albums AS (
 			SELECT id FROM albums WHERE id = ?
 			UNION ALL
-			SELECT a.id FROM albums a
-			INNER JOIN sub_albums sa ON a.parent_album_id = sa.id
+			SELECT child.id FROM albums AS child
+			INNER JOIN sub_albums ON child.parent_album_id = sub_albums.id
 		)
 		SELECT m.* FROM media AS m
 		INNER JOIN media_urls AS mu ON mu.media_id = m.id

--- a/api/graphql/models/album.go
+++ b/api/graphql/models/album.go
@@ -97,8 +97,8 @@ func (a *Album) Thumbnail(db *gorm.DB) (*Media, error) {
 			SELECT a.id FROM albums a
 			INNER JOIN sub_albums sa ON a.parent_album_id = sa.id
 		)
-		SELECT m.* FROM media m
-		INNER JOIN media_urls mu ON mu.media_id = m.id
+		SELECT m.* FROM media AS m
+		INNER JOIN media_urls AS mu ON mu.media_id = m.id
 		WHERE m.album_id IN (SELECT id FROM sub_albums)
 		LIMIT 1
 	`

--- a/api/graphql/models/album.go
+++ b/api/graphql/models/album.go
@@ -83,26 +83,28 @@ func GetParentsFromAlbums(db *gorm.DB, filter func(*gorm.DB) *gorm.DB, albumID i
 func (a *Album) Thumbnail(db *gorm.DB) (*Media, error) {
 	var media Media
 
-	if a.CoverID == nil {
-		if err := db.Raw(`
-			WITH recursive sub_albums AS (
-				SELECT * FROM albums AS root WHERE id = ?
-				UNION ALL
-				SELECT child.* FROM albums AS child JOIN sub_albums ON child.parent_album_id = sub_albums.id
-			)
+	if a.CoverID != nil {
+		if err := db.First(&media, *a.CoverID).Error; err != nil {
+			return nil, err
+		}
+		return &media, nil
+	}
 
-			SELECT * FROM media WHERE media.album_id IN (
-				SELECT id FROM sub_albums
-			) AND media.id IN (
-				SELECT media_id FROM media_urls WHERE media_urls.media_id = media.id
-			) ORDER BY id LIMIT 1
-		`, a.ID).Find(&media).Error; err != nil {
-			return nil, err
-		}
-	} else {
-		if err := db.Where("id = ?", a.CoverID).Find(&media).Error; err != nil {
-			return nil, err
-		}
+	query := `
+		WITH RECURSIVE sub_albums AS (
+			SELECT id FROM albums WHERE id = ?
+			UNION ALL
+			SELECT a.id FROM albums a
+			INNER JOIN sub_albums sa ON a.parent_album_id = sa.id
+		)
+		SELECT m.* FROM media m
+		INNER JOIN media_urls mu ON mu.media_id = m.id
+		WHERE m.album_id IN (SELECT id FROM sub_albums)
+		LIMIT 1
+	`
+
+	if err := db.Raw(query, a.ID).Scan(&media).Error; err != nil {
+		return nil, err
 	}
 
 	return &media, nil


### PR DESCRIPTION
### Intro 

I noticed a degradation in performance due to the `Thumbnail` function. On a larger instance I have, it took minutes to open the main Album page.

### Changes

This PR contains the following adjustments:

- minor code refactoring to make the code more readable
- refactoring of the `WITH` clause to only include ids (and not any other data)
- refactoring of the main `SELECT` clause to avoid costly `IN` queries and replace them with a `JOIN`
- refactoring of the main `SELECT` clause to drop the `ORDER BY` which caused a significant performance overhead

### Performance Difference

There are obviously some caveats. I did a single run on my local instance. But the performance difference is clearly noticeable.

**Before:**

```
[66373.397ms] [rows:1]
			WITH recursive sub_albums AS (
				SELECT * FROM albums AS root WHERE id = 5
				UNION ALL
				SELECT child.* FROM albums AS child JOIN sub_albums ON child.parent_album_id = sub_albums.id
			)

			SELECT * FROM media WHERE media.album_id IN (
				SELECT id FROM sub_albums
			) AND media.id IN (
				SELECT media_id FROM media_urls WHERE media_urls.media_id = media.id
			) ORDER BY id LIMIT 1
```

**After:**

```
[413.015ms] [rows:1]
		WITH RECURSIVE sub_albums AS (
			SELECT id FROM albums WHERE id = 5
			UNION ALL
			SELECT a.id FROM albums a
			INNER JOIN sub_albums sa ON a.parent_album_id = sa.id
		)
		SELECT m.* FROM media m
		INNER JOIN media_urls mu ON mu.media_id = m.id
		WHERE m.album_id IN (SELECT id FROM sub_albums)
		LIMIT 1
```

A speedup of >100x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved album thumbnail retrieval logic to handle cover media more efficiently.
	- Optimized media selection process for albums with and without explicit cover media.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->