### PR TITLE
Fix album page being empty for users with overlapping paths

### DIFF
--- a/api/graphql/models/actions/album_actions.go
+++ b/api/graphql/models/actions/album_actions.go
@@ -31,7 +31,7 @@ func MyAlbums(db *gorm.DB, user *models.User, order *models.Ordering, paginate *
 		if singleRootAlbumID != -1 && len(user.Albums) > 1 {
 			query = query.Where("parent_album_id = ?", singleRootAlbumID)
 		} else {
-			query = query.Where("parent_album_id IS NULL")
+			query = query.Where("parent_album_id IS NULL OR parent_album_id NOT IN (?)", userAlbumIDs)
 		}
 	}
 


### PR DESCRIPTION
Fixes #658, where users with overlapping paths will cause the album page to be empty.

I tested it with the following folder structure:
```
/app/photos_path/
   2023/
      2023-01/
   2024/
```

and these users:

| Username | Photo path |
| ----------- | ------------ |
| Admin       | /app/photos_path                         |
| Test1         | /app/photos_path/2023                |
|                  | /app/photos_path/2024                |
| Test2         | /app/photos_path/2023/2023-01 |
| Test3         | /app/photos_path/2023/2023-01 |
|                  | /app/photos_path/2024                |

And it works as expected. I would like someone else to test to make sure it works, but from my testing with this setup it all works as I expect it to:
* Admin can see all folders
* Test1 can see all folders
* Test2 can only see the 2023-01 folder
* Test3 can see the 2024 folder, and the 2023-01 folder but not the 2023 folder
* Giving a user access to a folder grants it access to all subfolders
* Users are presented with the highest level folders, but can dive deeper by clicking a folder to see the potential subfolders

However, in doing this testing I noticed a related bug that I will open an issue for. However, the bug is not caused by this PR and so is a separate issue.