### PR TITLE
Fix development mySQL URL pointing to non-existing container

### DIFF
--- a/dev-compose.yaml
+++ b/dev-compose.yaml
@@ -31,7 +31,7 @@ services:
     environment:
       PHOTOVIEW_DATABASE_DRIVER: sqlite # Change to the right database driver
       PHOTOVIEW_SQLITE_PATH: photoview.db
-      PHOTOVIEW_MYSQL_URL: photoview:photosecret@tcp(mysql)/photoview_test
+      PHOTOVIEW_MYSQL_URL: photoview:photosecret@tcp(mariadb)/photoview_test
       PHOTOVIEW_POSTGRES_URL: postgres://photoview:photosecret@postgres:5432/photoview_test
     volumes:
       - .:/app:rw


### PR DESCRIPTION
The development mySQL URL is pointing to a non-existing container. This PR switches it to point at the `mariadb` container part of the compose file.

Currently, if you just change the `PHOTOVIEW_DATABASE_DRIVER` to `mysql`, you will get connection errors since the URL is wrong. This fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Update**
	- Updated database connection configuration to use MariaDB driver instead of MySQL driver in development environment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->