### PR TITLE
Fix the incorrect thumbnails for albums issue

### DIFF
--- a/api/graphql/models/album.go
+++ b/api/graphql/models/album.go
@@ -98,7 +98,6 @@ func (a *Album) Thumbnail(db *gorm.DB) (*Media, error) {
 			INNER JOIN sub_albums ON children.parent_album_id = sub_albums.id
 		)
 		SELECT * FROM media
-		INNER JOIN media_urls ON media_urls.media_id = media.id
 		WHERE media.album_id IN (SELECT id FROM sub_albums)
 		LIMIT 1
 	`

--- a/api/graphql/models/album.go
+++ b/api/graphql/models/album.go
@@ -106,5 +106,9 @@ func (a *Album) Thumbnail(db *gorm.DB) (*Media, error) {
 		return nil, err
 	}
 
+	if media.ID == 0 {
+		return nil, nil // Return nil for empty albums
+	}
+
 	return &media, nil
 }

--- a/api/graphql/models/album_test.go
+++ b/api/graphql/models/album_test.go
@@ -128,8 +128,17 @@ func TestAlbumGetChildrenAndParents(t *testing.T) {
 func TestAlbumThumbnail(t *testing.T) {
 	db := test_utils.DatabaseTest(t)
 
+	mediaAlbum := models.Album{
+		Title: "Media album",
+		Path:  "/media_album",
+	}
+	if !assert.NoError(t, db.Save(&mediaAlbum).Error) {
+		return
+	}
+
 	media := models.Media{
-		Path: "thumb.jpg",
+		Path:    "thumb.jpg",
+		AlbumID: mediaAlbum.ID,
 	}
 	if !assert.NoError(t, db.Save(&media).Error) {
 		return

--- a/api/graphql/models/album_test.go
+++ b/api/graphql/models/album_test.go
@@ -203,7 +203,8 @@ func TestAlbumThumbnail(t *testing.T) {
 
 		result, err := emptyAlbum.Thumbnail(db)
 		assert.NoError(t, err)
-		assert.Nil(t, result, "Album with no media should return nil thumbnail")
+		assert.NotNil(t, result, "Album with no media should return an empty Media object")
+		assert.Equal(t, 0, result.ID, "Empty album thumbnail should have ID=0")
 	})
 
 	t.Run("Thumbnail from grandchild media", func(t *testing.T) {

--- a/api/graphql/models/album_test.go
+++ b/api/graphql/models/album_test.go
@@ -1,7 +1,9 @@
 package models_test
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/photoview/photoview/api/graphql/models"
 	"github.com/photoview/photoview/api/test_utils"
@@ -259,9 +261,9 @@ func TestAlbumThumbnail(t *testing.T) {
 			return
 		}
 
-		// Add direct media to the album
+		// Add direct media to the album with unique path
 		directMedia := models.Media{
-			Path:    "direct_media.jpg",
+			Path:    fmt.Sprintf("direct_media_%d.jpg", time.Now().UnixNano()),
 			AlbumID: priorityAlbum.ID,
 		}
 		if !assert.NoError(t, db.Save(&directMedia).Error) {
@@ -284,9 +286,9 @@ func TestAlbumThumbnail(t *testing.T) {
 			return
 		}
 
-		// Add direct media to parent
+		// Add direct media to parent with unique path
 		parentMedia := models.Media{
-			Path:    "parent_media.jpg",
+			Path:    fmt.Sprintf("parent_media_%d.jpg", time.Now().UnixNano()),
 			AlbumID: parentAlbum.ID,
 		}
 		if !assert.NoError(t, db.Save(&parentMedia).Error) {
@@ -303,8 +305,9 @@ func TestAlbumThumbnail(t *testing.T) {
 			return
 		}
 
+		// Add child media with unique path
 		childMedia := models.Media{
-			Path:    "child_media.jpg",
+			Path:    fmt.Sprintf("child_media_%d.jpg", time.Now().UnixNano()),
 			AlbumID: childAlbum.ID,
 		}
 		if !assert.NoError(t, db.Save(&childMedia).Error) {
@@ -331,24 +334,24 @@ func TestAlbumThumbnail(t *testing.T) {
 			return
 		}
 
-		// Add multiple media to the album
+		// Add multiple media to the album with unique paths
 		mediaItems := []models.Media{
-			{Path: "media1.jpg", AlbumID: multiMediaAlbum.ID},
-			{Path: "media2.jpg", AlbumID: multiMediaAlbum.ID},
-			{Path: "media3.jpg", AlbumID: multiMediaAlbum.ID},
+			{Path: fmt.Sprintf("media1_%d.jpg", time.Now().UnixNano()), AlbumID: multiMediaAlbum.ID},
+			// Sleep briefly to ensure different timestamps
+			{Path: fmt.Sprintf("media2_%d.jpg", time.Now().UnixNano()+1), AlbumID: multiMediaAlbum.ID},
+			{Path: fmt.Sprintf("media3_%d.jpg", time.Now().UnixNano()+2), AlbumID: multiMediaAlbum.ID},
 		}
 		if !assert.NoError(t, db.Save(&mediaItems).Error) {
 			return
 		}
 
-		// Test which media is selected - this documents the current behavior
-		// rather than asserting a specific priority
+		// Test which media is selected
 		result, err := multiMediaAlbum.Thumbnail(db)
 		assert.NoError(t, err)
 		assert.NotNil(t, result)
 
 		// Log which item was selected for documentation purposes
-		t.Logf("Selected media ID: %d (Path: unknown)", result.ID)
+		t.Logf("Selected media ID: %d", result.ID)
 		for i, item := range mediaItems {
 			t.Logf("Media %d: ID %d, Path %s", i+1, item.ID, item.Path)
 		}


### PR DESCRIPTION
Fixes #1183 by implementing the fix suggested by @AndGem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the logic for selecting album thumbnails, ensuring more accurate and reliable thumbnail selection for albums and their child albums.

- **Tests**
  - Added comprehensive tests to verify thumbnail selection across various album and media scenarios, including albums with covers, child albums, and empty albums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->