### PR TITLE
More granular `media-cache` folder permissions

### DIFF
--- a/docker-compose example/Makefile
+++ b/docker-compose example/Makefile
@@ -59,7 +59,6 @@ start:
 	@# If you don't want to give 777 permissions to this folder, create a group with GID=999 (or user with UID=999 and group
 	@# with GID=999 and that user) and make the folder being owned by it, so you can give the 570 or 750 permissions correspondingly.
 	mkdir -p ${HOST_PHOTOVIEW_LOCATION}/storage
-	chmod 777 ${HOST_PHOTOVIEW_LOCATION}/storage
 	$(DOCKER_COMPOSE) up -d --remove-orphans
 	@## Uncomment the next line if you want to run an automatic cleanup of Docker leftovers
 	@## Make sure to read the Docker documentation to understand how it works

--- a/docker-compose example/docker-compose.example.yml
+++ b/docker-compose example/docker-compose.example.yml
@@ -1,4 +1,20 @@
 services:
+  ## Makes sure that the media cache folder is created with the correct permissions
+  photoview-prepare:
+    image: photoview/photoview:2
+    hostname: photoview-prepare
+    container_name: photoview-prepare
+    user: root
+    entrypoint: []
+    command: /bin/bash -c "sleep 1 && chown -R photoview:photoview /home/photoview/media-cache"
+    security_opt:
+      - seccomp:unconfined
+      - apparmor:unconfined
+    volumes:
+      - "/etc/localtime:/etc/localtime:ro" ## use local time from host
+      - "/etc/timezone:/etc/timezone:ro"   ## use timezone from host
+      - "${HOST_PHOTOVIEW_LOCATION}/storage:/home/photoview/media-cache"
+
   photoview:
     image: photoview/photoview:2
     labels:
@@ -13,6 +29,8 @@ services:
     ## Comment out the entire `depends_on` section if PHOTOVIEW_DATABASE_DRIVER is set to `sqlite` in the .env
     ## Or comment out the `mariadb:` and uncomment the `postgres:` if PHOTOVIEW_DATABASE_DRIVER is set to `postgres`
     depends_on:
+      photoview-prepare:
+        condition: service_completed_successfully
       # postgres:
       mariadb:
         condition: service_healthy
@@ -33,7 +51,11 @@ services:
       ## If you change this, remember to update the port mapping (under the `ports:`) above!
       # PHOTOVIEW_LISTEN_PORT: 80
       ## Uncomment the next variable and set a different value to set the location of the media cache inside the container.
-      ## If you change this, remember to update the right side of the storage volume mount (under the `volumes:`) below!
+      ## Make sure that you know why you are doing this.
+      ## If you change this, remember to update the corresponding paths in:
+      ## - the command of the `photoview-prepare` service
+      ## - the `photoview-prepare` service's right side of the storage volume mount (under the `volumes:`)
+      ## - the right side of the storage volume mount (under the `volumes:`) below
       # PHOTOVIEW_MEDIA_CACHE: "/home/photoview/media-cache"
       ## Optional: If you are using Samba/CIFS-Share and experience problems with "directory not found"
       ## Enable the following Godebug

--- a/docker-compose example/docker-compose.example.yml
+++ b/docker-compose example/docker-compose.example.yml
@@ -7,7 +7,8 @@ services:
     user: root
     entrypoint: []
     command: /bin/bash -c "sleep 1 && chown -R photoview:photoview /home/photoview/media-cache"
-    cap_add: [CHOWN]
+    cap_add:
+      - CHOWN
     volumes:
       - "/etc/localtime:/etc/localtime:ro" ## use local time from host
       - "/etc/timezone:/etc/timezone:ro"   ## use timezone from host

--- a/docker-compose example/docker-compose.example.yml
+++ b/docker-compose example/docker-compose.example.yml
@@ -7,9 +7,7 @@ services:
     user: root
     entrypoint: []
     command: /bin/bash -c "sleep 1 && chown -R photoview:photoview /home/photoview/media-cache"
-    security_opt:
-      - seccomp:unconfined
-      - apparmor:unconfined
+    cap_add: [CHOWN]
     volumes:
       - "/etc/localtime:/etc/localtime:ro" ## use local time from host
       - "/etc/timezone:/etc/timezone:ro"   ## use timezone from host

--- a/docker-compose example/docker-compose.minimal.example.yml
+++ b/docker-compose example/docker-compose.minimal.example.yml
@@ -7,7 +7,8 @@ services:
     user: root
     entrypoint: []
     command: /bin/bash -c "sleep 1 && chown -R photoview:photoview /home/photoview/media-cache"
-    cap_add: [CHOWN]
+    cap_add:
+      - CHOWN
     volumes:
       - "/etc/localtime:/etc/localtime:ro" ## use local time from host
       - "/etc/timezone:/etc/timezone:ro"   ## use timezone from host

--- a/docker-compose example/docker-compose.minimal.example.yml
+++ b/docker-compose example/docker-compose.minimal.example.yml
@@ -7,9 +7,7 @@ services:
     user: root
     entrypoint: []
     command: /bin/bash -c "sleep 1 && chown -R photoview:photoview /home/photoview/media-cache"
-    security_opt:
-      - seccomp:unconfined
-      - apparmor:unconfined
+    cap_add: [CHOWN]
     volumes:
       - "/etc/localtime:/etc/localtime:ro" ## use local time from host
       - "/etc/timezone:/etc/timezone:ro"   ## use timezone from host

--- a/docker-compose example/docker-compose.minimal.example.yml
+++ b/docker-compose example/docker-compose.minimal.example.yml
@@ -1,4 +1,20 @@
 services:
+  ## Makes sure that the media cache folder is created with the correct permissions
+  photoview-prepare:
+    image: photoview/photoview:2
+    hostname: photoview-prepare
+    container_name: photoview-prepare
+    user: root
+    entrypoint: []
+    command: /bin/bash -c "sleep 1 && chown -R photoview:photoview /home/photoview/media-cache"
+    security_opt:
+      - seccomp:unconfined
+      - apparmor:unconfined
+    volumes:
+      - "/etc/localtime:/etc/localtime:ro" ## use local time from host
+      - "/etc/timezone:/etc/timezone:ro"   ## use timezone from host
+      - "${HOST_PHOTOVIEW_LOCATION}/storage:/home/photoview/media-cache"
+
   photoview:
     image: photoview/photoview:2
     hostname: photoview
@@ -10,6 +26,8 @@ services:
     ## This ensures that DB is initialized and ready for connections.
     ## Comment out the entire `depends_on` section if PHOTOVIEW_DATABASE_DRIVER is set to `sqlite` in the .env
     depends_on:
+      photoview-prepare:
+        condition: service_completed_successfully
       mariadb:
         condition: service_healthy
     ## Security options for some restricted systems


### PR DESCRIPTION
Fixes #1181 

Add a preparation service to assign the correct permissions to the media cache folder instead of making it writable by anyone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a preparation step to Docker Compose setups to ensure correct permissions for the media cache directory before starting the main service.

- **Documentation**
  - Improved comments in configuration files to clarify how to update media cache paths and related settings.

- **Chores**
  - Adjusted Makefile and Docker Compose examples to manage directory permissions externally rather than setting them directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->