### PR TITLE
Drop linux/arm/v7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ env:
   DOCKER_USERNAME: viktorstrate
   DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
   DOCKER_IMAGE: ${{ github.repository }}
-  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   prepare:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -14,7 +14,7 @@ env:
   IS_CACHING: ${{ github.event_name == 'pull_request' }}
   DOCKER_USERNAME: viktorstrate
   DOCKER_IMAGE: photoview/dependencies
-  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   build:


### PR DESCRIPTION
Since the latest release of [jellyfin-ffmpeg](https://github.com/jellyfin/jellyfin-ffmpeg/releases/tag/v7.1.1-3) doesn't support `armhf`, we can't support `arm/v7` with the full feature. Just drop the platform.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated build and dependency workflows to remove support for the linux/arm/v7 platform. Future builds will target only linux/amd64 and linux/arm64 architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->