### PR TITLE
Include MagicWand library in the `dependency` image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ RUN --mount=type=bind,from=api,source=/dependencies/,target=/dependencies/ \
   && /app/scripts/install_runtime_dependencies.sh \
   # Install self-building libs
   && cd /dependencies \
-  && cp -a lib/* /usr/local/lib/ \
+  && cp -a lib/*.so* /usr/local/lib/ \
   && cp -a bin/* /usr/local/bin/ \
   && cp -a etc/* /usr/local/etc/ \
   && ldconfig \

--- a/dependencies/build_imagemagick.sh
+++ b/dependencies/build_imagemagick.sh
@@ -18,7 +18,15 @@ make
 make install
 cd ..
 
-mkdir -p /output/bin /output/etc
+mkdir -p /output/bin /output/etc /output/lib /output/include /output/pkgconfig
 cp /usr/local/bin/magick /output/bin/
-cp -r /usr/local/etc/ImageMagick-7 /output/etc/ImageMagick-7
+cp -r /usr/local/etc/ImageMagick-7 /output/etc/
+cp -r /usr/local/lib/ImageMagick-* /output/lib/
+cp -r /usr/local/lib/libMagickCore-* /output/lib/
+cp -r /usr/local/lib/libMagickWand-* /output/lib/
+cp -r /usr/local/lib/ImageMagick-* /output/lib/
+cp -r /usr/local/include/ImageMagick-7 /output/include/
+cp -r /usr/local/lib/pkgconfig/ImageMagick*.pc /output/pkgconfig/
+cp -r /usr/local/lib/pkgconfig/MagickCore*.pc /output/pkgconfig/
+cp -r /usr/local/lib/pkgconfig/MagickWand*.pc /output/pkgconfig/
 file /output/bin/magick

--- a/dependencies/build_imagemagick.sh
+++ b/dependencies/build_imagemagick.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -eu
+#!/bin/bash
+set -euo pipefail
 
 : ${DEB_HOST_MULTIARCH=`uname -m`-linux-gnu}
 : ${DEB_HOST_ARCH=`dpkg --print-architecture`}

--- a/dependencies/build_imagemagick.sh
+++ b/dependencies/build_imagemagick.sh
@@ -24,7 +24,6 @@ cp -r /usr/local/etc/ImageMagick-7 /output/etc/
 cp -r /usr/local/lib/ImageMagick-* /output/lib/
 cp -r /usr/local/lib/libMagickCore-* /output/lib/
 cp -r /usr/local/lib/libMagickWand-* /output/lib/
-cp -r /usr/local/lib/ImageMagick-* /output/lib/
 cp -r /usr/local/include/ImageMagick-7 /output/include/
 cp -r /usr/local/lib/pkgconfig/ImageMagick*.pc /output/pkgconfig/
 cp -r /usr/local/lib/pkgconfig/MagickCore*.pc /output/pkgconfig/

--- a/dependencies/build_imagemagick.sh
+++ b/dependencies/build_imagemagick.sh
@@ -20,12 +20,12 @@ cd ..
 
 mkdir -p /output/bin /output/etc /output/lib /output/include /output/pkgconfig
 cp /usr/local/bin/magick /output/bin/
-cp -r /usr/local/etc/ImageMagick-7 /output/etc/
-cp -r /usr/local/lib/ImageMagick-* /output/lib/
-cp -r /usr/local/lib/libMagickCore-* /output/lib/
-cp -r /usr/local/lib/libMagickWand-* /output/lib/
-cp -r /usr/local/include/ImageMagick-7 /output/include/
-cp -r /usr/local/lib/pkgconfig/ImageMagick*.pc /output/pkgconfig/
-cp -r /usr/local/lib/pkgconfig/MagickCore*.pc /output/pkgconfig/
-cp -r /usr/local/lib/pkgconfig/MagickWand*.pc /output/pkgconfig/
+cp -a /usr/local/etc/ImageMagick-7 /output/etc/
+cp -a /usr/local/lib/ImageMagick-* /output/lib/
+cp -a /usr/local/lib/libMagickCore-* /output/lib/
+cp -a /usr/local/lib/libMagickWand-* /output/lib/
+cp -a /usr/local/include/ImageMagick-7 /output/include/
+cp -a /usr/local/lib/pkgconfig/ImageMagick*.pc /output/pkgconfig/
+cp -a /usr/local/lib/pkgconfig/MagickCore*.pc /output/pkgconfig/
+cp -a /usr/local/lib/pkgconfig/MagickWand*.pc /output/pkgconfig/
 file /output/bin/magick

--- a/dependencies/build_libheif.sh
+++ b/dependencies/build_libheif.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -eu
+#!/bin/bash
+set -euo pipefail
 
 : ${DEB_HOST_MULTIARCH=`uname -m`-linux-gnu}
 : ${DEB_HOST_ARCH=`dpkg --print-architecture`}

--- a/dependencies/build_libraw.sh
+++ b/dependencies/build_libraw.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -eu
+#!/bin/bash
+set -euo pipefail
 
 : ${DEB_HOST_MULTIARCH=`uname -m`-linux-gnu}
 : ${DEB_HOST_ARCH=`dpkg --print-architecture`}

--- a/dependencies/output.sh
+++ b/dependencies/output.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -eu
+#!/bin/bash
+set -euo pipefail
 
 cd /output
 tar czfv /artifacts.tar.gz *

--- a/dependencies/prepare.sh
+++ b/dependencies/prepare.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -eu
+#!/bin/bash
+set -euo pipefail
 
 : ${TARGETPLATFORM=linux/`dpkg --print-architecture`}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved the build process to organize ImageMagick binaries, libraries, headers, and configuration files into dedicated output directories for easier access and management.
  - Refined the Docker image build to include only necessary shared library files, optimizing image size and content.
  - Enhanced script reliability by updating shell interpreters and enabling stricter error handling across build and preparation scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->