### PR TITLE
Fix a race condition in the Periodic Scanner module

### DIFF
--- a/api/scanner/periodic_scanner/periodic_scanner.go
+++ b/api/scanner/periodic_scanner/periodic_scanner.go
@@ -76,15 +76,19 @@ func ChangePeriodicScanInterval(duration time.Duration) {
 func scanIntervalRunner() {
 	for {
 		log.Print("Scan interval runner: Waiting for signal")
-		if mainPeriodicScanner.ticker != nil {
+		mainPeriodicScanner.mutex.Lock()
+		ticker := mainPeriodicScanner.ticker
+		if ticker != nil {
+			mainPeriodicScanner.mutex.Unlock()
 			select {
 			case <-mainPeriodicScanner.ticker_changed:
 				log.Print("Scan interval runner: New ticker detected")
-			case <-mainPeriodicScanner.ticker.C:
+			case <-ticker.C:
 				log.Print("Scan interval runner: Starting periodic scan")
 				scanner_queue.AddAllToQueue()
 			}
 		} else {
+			mainPeriodicScanner.mutex.Unlock()
 			<-mainPeriodicScanner.ticker_changed
 			log.Print("Scan interval runner: New ticker detected")
 		}


### PR DESCRIPTION
This PR was initiated by the issue, detected by the Coverity scanner in my forked repo:

> CID 1588234: Data race condition (GUARDED_BY_VIOLATION)
> missing_lock: Accessing mainPeriodicScanner.ticker without holding lock periodic_scanner.periodicScanner.mutex. Elsewhere, periodic_scanner.periodicScanner.ticker is written to with periodic_scanner.periodicScanner.mutex held 1 out of 1 times.