### PR TITLE
Change default thumbnail of album.

### DIFF
--- a/api/graphql/models/actions/album_actions_test.go
+++ b/api/graphql/models/actions/album_actions_test.go
@@ -163,8 +163,8 @@ func TestAlbumCover(t *testing.T) {
 			albumThumb, err := album.Thumbnail(db)
 			assert.NoError(t, err)
 
-			// Should return pic1 since no coverID has been set
-			assert.EqualValues(t, "pic1", albumThumb.Title)
+			// Should return the latest photo since no coverID has been set
+			assert.EqualValues(t, "pic6", albumThumb.Title)
 		}
 
 		{
@@ -186,7 +186,7 @@ func TestAlbumCover(t *testing.T) {
 		resetThumb, err := resetAlbum.Thumbnail(db)
 		assert.NoError(t, err)
 
-		assert.Equal(t, "pic3", resetThumb.Title)
+		assert.Equal(t, "pic4", resetThumb.Title)
 	})
 
 	t.Run("Album change cover photos", func(t *testing.T) {

--- a/api/graphql/models/album.go
+++ b/api/graphql/models/album.go
@@ -99,7 +99,7 @@ func (a *Album) Thumbnail(db *gorm.DB) (*Media, error) {
 		)
 		SELECT * FROM media
 		WHERE media.album_id IN (SELECT id FROM sub_albums)
-		ORDER BY media.id
+		ORDER BY media.id DESC
 		LIMIT 1
 	`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated album cover selection to use the most recent photo as the default thumbnail when no specific cover is set or after a reset.

* **Tests**
  * Adjusted test cases to align with the new default album cover selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->