### PR TITLE
Fix the local build of the dependencies image, including the debug image instructions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,10 +131,10 @@ jobs:
           annotations: ${{ steps.docker_meta.outputs.annotations }}
           cache-from: |
             type=gha,scope=test-ui-${{ hashFiles('ui/package-lock.json') }}
-            type=gha,scope=test-api-${{ hashFiles('api/go.sum', 'scripts/install_*.sh') }}
+            type=gha,scope=test-api-${{ hashFiles('api/go.sum', 'scripts/install_*.sh', 'dependencies/*') }}
           cache-to: |
             type=gha,mode=max,scope=test-ui-${{ hashFiles('ui/package-lock.json') }}
-            type=gha,mode=max,scope=test-api-${{ hashFiles('api/go.sum', 'scripts/install_*.sh') }}
+            type=gha,mode=max,scope=test-api-${{ hashFiles('api/go.sum', 'scripts/install_*.sh', 'dependencies/*') }}
           build-args: |
             NODE_ENV=production
             VERSION=${{ github.ref_name }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,8 +61,7 @@ jobs:
         load:       true
         target:     api
         tags:       photoview/api
-        cache-from: type=gha,scope=test-api-${{ hashFiles('api/go.sum', 'scripts/install_*.sh') }}
-        cache-to:   type=gha,mode=max,scope=test-api-${{ hashFiles('api/go.sum', 'scripts/install_*.sh') }}
+        cache-from: type=gha,scope=test-api-${{ hashFiles('api/go.sum', 'scripts/install_*.sh', 'dependencies/*') }}
 
     - name: Test
       id: test
@@ -113,7 +112,6 @@ jobs:
         target:     ui
         tags:       photoview/ui
         cache-from: type=gha,scope=test-ui-${{ hashFiles('ui/package-lock.json') }}
-        cache-to:   type=gha,mode=max,scope=test-ui-${{ hashFiles('ui/package-lock.json') }}
         build-args: |
           NODE_ENV=testing
 

--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -61,6 +61,5 @@ COPY --from=download-jellyfin-ffmpeg /output/ /output/
 COPY --chmod=0755 output.sh /
 RUN /output.sh
 
-FROM scratch AS release
+FROM debian:bookworm-slim AS release
 COPY --from=final-assembly /artifacts.tar.gz /
-USER nobody

--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -13,7 +13,9 @@ WORKDIR /tmp/build-libraw
 COPY --chmod=0755 build_libraw.sh .
 RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=libraw-${TARGETARCH}-${LIBRAW_VERSION} \
     --mount=type=secret,id=github_token \
-    export GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    if [ -f /run/secrets/github_token ]; then \
+    export GITHUB_TOKEN=$(cat /run/secrets/github_token); \
+    fi \
     && export $(cat /env) && ./build_libraw.sh
 
 FROM base-prep AS build-libheif
@@ -24,7 +26,9 @@ WORKDIR /tmp/build-libheif
 COPY --chmod=0755 build_libheif.sh .
 RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=libheif-${TARGETARCH}-${LIBHEIF_VERSION} \
     --mount=type=secret,id=github_token \
-    export GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    if [ -f /run/secrets/github_token ]; then \
+    export GITHUB_TOKEN=$(cat /run/secrets/github_token); \
+    fi \
     && export $(cat /env) && ./build_libheif.sh
 
 FROM base-prep AS build-imagemagick
@@ -35,7 +39,9 @@ WORKDIR /tmp/build-imagemagick
 COPY --chmod=0755 build_imagemagick.sh .
 RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=imagemagick-${TARGETARCH}-${IMAGEMAGICK_VERSION} \
     --mount=type=secret,id=github_token \
-    export GITHUB_TOKEN=$(cat /run/secrets/github_token) \
+    if [ -f /run/secrets/github_token ]; then \
+    export GITHUB_TOKEN=$(cat /run/secrets/github_token); \
+    fi \
     && export $(cat /env) && ./build_imagemagick.sh
 
 FROM base-prep AS download-jellyfin-ffmpeg

--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -36,6 +36,8 @@ ARG IMAGEMAGICK_VERSION
 ARG TARGETARCH
 ENV BUILD_CACHE_DIR=/build-cache
 WORKDIR /tmp/build-imagemagick
+COPY --from=build-libraw /output/ /libs/
+COPY --from=build-libheif /output/ /libs/
 COPY --chmod=0755 build_imagemagick.sh .
 RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=imagemagick-${TARGETARCH}-${IMAGEMAGICK_VERSION} \
     --mount=type=secret,id=github_token \

--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -18,7 +18,7 @@ RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=libraw-${TARGETARCH}-${LIBRA
     fi \
     && export $(cat /env) && ./build_libraw.sh
 
-FROM base-prep AS build-libheif
+FROM build-libraw AS build-libheif
 ARG LIBHEIF_VERSION
 ARG TARGETARCH
 ENV BUILD_CACHE_DIR=/build-cache
@@ -31,13 +31,11 @@ RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=libheif-${TARGETARCH}-${LIBH
     fi \
     && export $(cat /env) && ./build_libheif.sh
 
-FROM base-prep AS build-imagemagick
+FROM build-libheif AS build-imagemagick
 ARG IMAGEMAGICK_VERSION
 ARG TARGETARCH
 ENV BUILD_CACHE_DIR=/build-cache
 WORKDIR /tmp/build-imagemagick
-COPY --from=build-libraw /output/ /libs/
-COPY --from=build-libheif /output/ /libs/
 COPY --chmod=0755 build_imagemagick.sh .
 RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=imagemagick-${TARGETARCH}-${IMAGEMAGICK_VERSION} \
     --mount=type=secret,id=github_token \

--- a/dependencies/Dockerfile-debug
+++ b/dependencies/Dockerfile-debug
@@ -1,0 +1,2 @@
+FROM debian:bookworm-slim
+COPY --from=dependencies:self /artifacts.tar.gz /

--- a/dependencies/Dockerfile-debug
+++ b/dependencies/Dockerfile-debug
@@ -1,2 +1,0 @@
-FROM debian:bookworm-slim
-COPY --from=dependencies:self /artifacts.tar.gz /

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -1,3 +1,24 @@
 # Dependencies
 
 This directory contains scripts and Dockerfile to build third-party dependencies for Photoview. It is not intended for end-users or runtime execution.
+
+To locally debug this image you need to run 2 simple steps:
+
+1. Build the image locally and tag it as `dependencies:self`. For example:
+
+    `docker buildx build --pull --tag dependencies:self .`
+
+2. Build the debug image, which you then can run and investigate the content:
+
+    `docker buildx build --pull --tag deps-debug --file ./Dockerfile-debug .`
+
+Now you can run the debug image by:
+
+`docker run --rm -it deps-debug /bin/bash`
+
+Alternatively, you can build it up to the `final-assembly` target and run it:
+
+```bash
+docker buildx build --security-opt seccomp=unconfined --pull --target final-assembly --tag dependencies:self .
+docker run --rm -it dependencies:self /bin/bash
+```

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -2,6 +2,11 @@
 
 This directory contains scripts and Dockerfile to build third-party dependencies for Photoview. It is not intended for end-users or runtime execution.
 
-However, technically it is runnable for easy debug and investigation purposes.
-It contains 1 archive file `artifacts.tar.gz` with all the dependencies inside.
-To unpack it, you can use the `tar -xzf artifacts.tar.gz [-C /desired/location]` command.
+However, technically, it is runnable for debugging and investigative purposes.
+It contains a single archive file, `artifacts.tar.gz`, that bundles all dependencies.
+
+You can unpack it with:
+
+```bash
+tar -xzf artifacts.tar.gz [-C /desired/location]
+```

--- a/dependencies/README.md
+++ b/dependencies/README.md
@@ -2,23 +2,6 @@
 
 This directory contains scripts and Dockerfile to build third-party dependencies for Photoview. It is not intended for end-users or runtime execution.
 
-To locally debug this image you need to run 2 simple steps:
-
-1. Build the image locally and tag it as `dependencies:self`. For example:
-
-    `docker buildx build --pull --tag dependencies:self .`
-
-2. Build the debug image, which you then can run and investigate the content:
-
-    `docker buildx build --pull --tag deps-debug --file ./Dockerfile-debug .`
-
-Now you can run the debug image by:
-
-`docker run --rm -it deps-debug /bin/bash`
-
-Alternatively, you can build it up to the `final-assembly` target and run it:
-
-```bash
-docker buildx build --security-opt seccomp=unconfined --pull --target final-assembly --tag dependencies:self .
-docker run --rm -it dependencies:self /bin/bash
-```
+However, technically it is runnable for easy debug and investigation purposes.
+It contains 1 archive file `artifacts.tar.gz` with all the dependencies inside.
+To unpack it, you can use the `tar -xzf artifacts.tar.gz [-C /desired/location]` command.

--- a/dependencies/build_imagemagick.sh
+++ b/dependencies/build_imagemagick.sh
@@ -27,15 +27,7 @@ echo "Building ImageMagick ${IMAGEMAGICK_VERSION} (cache miss)..."
 
 echo Compiler: "${DEB_HOST_MULTIARCH}" Arch: "${DEB_HOST_ARCH}"
 
-echo "PKG_CONFIG_PATH = ${PKG_CONFIG_PATH}"
-mkdir -p /usr/local/bin /usr/local/include /usr/local/lib/pkgconfig /usr/local/lib
-cp -a /libs/bin/* /usr/local/bin/
-cp -a /libs/include/* /usr/local/include/
-cp -a /libs/pkgconfig/* /usr/local/lib/pkgconfig/
-cp -a /libs/lib/* /usr/local/lib/
-ldconfig
-
-apt-get install -y --no-install-recommends \
+apt-get install -y \
   libjxl-dev:"${DEB_HOST_ARCH}" \
   liblcms2-dev:"${DEB_HOST_ARCH}" \
   liblqr-1-0-dev:"${DEB_HOST_ARCH}" \

--- a/dependencies/build_imagemagick.sh
+++ b/dependencies/build_imagemagick.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-set -euo pipefail
 
 # Fallback to the latest version if IMAGEMAGICK_VERSION is not set
-if [[ -z "$IMAGEMAGICK_VERSION" ]]; then
+if [[ -z "${IMAGEMAGICK_VERSION}" ]]; then
   echo "WARN: ImageMagick version is empty, most likely the script runs not on CI."
   echo "Fetching the latest version from ImageMagick repo..."
   IMAGEMAGICK_VERSION=$(curl -fsSL --retry 2 --retry-delay 5 --retry-max-time 60 \
     "https://api.github.com/repos/ImageMagick/ImageMagick/releases/latest" | jq -r '.tag_name')
 fi
+
+set -euo pipefail
 
 : "${DEB_HOST_MULTIARCH:=$(uname -m)-linux-gnu}"
 : "${DEB_HOST_ARCH:=$(dpkg --print-architecture)}"

--- a/dependencies/build_imagemagick.sh
+++ b/dependencies/build_imagemagick.sh
@@ -27,6 +27,12 @@ echo "Building ImageMagick ${IMAGEMAGICK_VERSION} (cache miss)..."
 
 echo Compiler: "${DEB_HOST_MULTIARCH}" Arch: "${DEB_HOST_ARCH}"
 
+cp -a /libs/bin/* /usr/local/bin/
+cp -a /libs/include/* /usr/local/include/
+cp -a /libs/pkgconfig/* /usr/local/lib/pkgconfig/
+cp -a /libs/lib/* /usr/local/lib/
+ldconfig
+
 apt-get install -y --no-install-recommends \
   libjxl-dev:"${DEB_HOST_ARCH}" \
   liblcms2-dev:"${DEB_HOST_ARCH}" \

--- a/dependencies/build_imagemagick.sh
+++ b/dependencies/build_imagemagick.sh
@@ -27,6 +27,8 @@ echo "Building ImageMagick ${IMAGEMAGICK_VERSION} (cache miss)..."
 
 echo Compiler: "${DEB_HOST_MULTIARCH}" Arch: "${DEB_HOST_ARCH}"
 
+echo "PKG_CONFIG_PATH = ${PKG_CONFIG_PATH}"
+mkdir -p /usr/local/bin /usr/local/include /usr/local/lib/pkgconfig /usr/local/lib
 cp -a /libs/bin/* /usr/local/bin/
 cp -a /libs/include/* /usr/local/include/
 cp -a /libs/pkgconfig/* /usr/local/lib/pkgconfig/

--- a/dependencies/build_libheif.sh
+++ b/dependencies/build_libheif.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-set -euo pipefail
 
 # Fallback to the latest version if LIBHEIF_VERSION is not set
-if [[ -z "$LIBHEIF_VERSION" ]]; then
+if [[ -z "${LIBHEIF_VERSION}" ]]; then
   echo "WARN: libheif version is empty, most likely the script runs not on CI."
   echo "Fetching the latest version from libheif repo..."
   LIBHEIF_VERSION=$(curl -fsSL --retry 2 --retry-delay 5 --retry-max-time 60 \
     "https://api.github.com/repos/strukturag/libheif/releases/latest" | jq -r '.tag_name')
 fi
+
+set -euo pipefail
 
 : "${DEB_HOST_MULTIARCH:=$(uname -m)-linux-gnu}"
 : "${DEB_HOST_ARCH:=$(dpkg --print-architecture)}"

--- a/dependencies/build_libheif.sh
+++ b/dependencies/build_libheif.sh
@@ -27,7 +27,7 @@ echo "Building libheif ${LIBHEIF_VERSION} (cache miss)..."
 
 echo Compiler: "${DEB_HOST_MULTIARCH}" Arch: "${DEB_HOST_ARCH}"
 
-apt-get install -y --no-install-recommends \
+apt-get install -y \
   libdav1d-dev:"${DEB_HOST_ARCH}" \
   libde265-dev:"${DEB_HOST_ARCH}" \
   libjpeg62-turbo-dev:"${DEB_HOST_ARCH}" \

--- a/dependencies/build_libraw.sh
+++ b/dependencies/build_libraw.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-set -euo pipefail
 
 # Fallback to the latest version if LIBRAW_VERSION is not set
-if [[ -z "$LIBRAW_VERSION" ]]; then
+if [[ -z "${LIBRAW_VERSION}" ]]; then
   echo "WARN: LibRaw version is empty, most likely the script runs not on CI."
   echo "Fetching the latest version from LibRaw repo..."
   LIBRAW_VERSION=$(curl -fsSL --retry 2 --retry-delay 5 --retry-max-time 60 \
     "https://api.github.com/repos/LibRaw/LibRaw/releases/latest" | jq -r '.tag_name')
 fi
+
+set -euo pipefail
 
 : "${DEB_HOST_MULTIARCH:=$(uname -m)-linux-gnu}"
 : "${DEB_HOST_ARCH:=$(dpkg --print-architecture)}"

--- a/dependencies/build_libraw.sh
+++ b/dependencies/build_libraw.sh
@@ -27,7 +27,7 @@ echo "Building LibRaw ${LIBRAW_VERSION} (cache miss)..."
 
 echo Compiler: "${DEB_HOST_MULTIARCH}" Arch: "${DEB_HOST_ARCH}"
 
-apt-get install -y --no-install-recommends \
+apt-get install -y \
   libjpeg62-turbo-dev:"${DEB_HOST_ARCH}" \
   liblcms2-dev:"${DEB_HOST_ARCH}" \
   zlib1g-dev:"${DEB_HOST_ARCH}"

--- a/dependencies/download_jellyfin-ffmpeg.sh
+++ b/dependencies/download_jellyfin-ffmpeg.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
-set -euo pipefail
 
 # Fallback to the latest version if JELLYFIN_FFMPEG_VERSION is not set
-if [[ -z "$JELLYFIN_FFMPEG_VERSION" ]]; then
+if [[ -z "${JELLYFIN_FFMPEG_VERSION}" ]]; then
   echo "WARN: jellyfin-ffmpeg version is empty, most likely the script runs not on CI."
   echo "Fetching the latest version from jellyfin-ffmpeg repo..."
   JELLYFIN_FFMPEG_VERSION=$(curl -fsSL --retry 2 --retry-delay 5 --retry-max-time 60 \
     "https://api.github.com/repos/jellyfin/jellyfin-ffmpeg/releases/latest" | jq -r '.tag_name')
 fi
+
+set -euo pipefail
 
 : "${DEB_HOST_MULTIARCH:=$(uname -m)-linux-gnu}"
 : "${DEB_HOST_ARCH:=$(dpkg --print-architecture)}"

--- a/dependencies/prepare.sh
+++ b/dependencies/prepare.sh
@@ -15,6 +15,7 @@ dpkg --add-architecture "$DEBIAN_ARCH"
 apt-get update
 apt-get install -y --no-install-recommends \
   curl \
+  jq \
   ca-certificates \
   crossbuild-essential-"${DEBIAN_ARCH}" \
   libc-dev:"${DEBIAN_ARCH}" \

--- a/dependencies/prepare.sh
+++ b/dependencies/prepare.sh
@@ -13,7 +13,7 @@ fi
 
 dpkg --add-architecture "$DEBIAN_ARCH"
 apt-get update
-apt-get install -y --no-install-recommends \
+apt-get install -y \
   curl \
   jq \
   ca-certificates \


### PR DESCRIPTION
Fixes #1227 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README with details on running the dependencies directory for debugging and instructions for unpacking the dependencies archive.

* **Chores**
  * Improved handling of the GITHUB_TOKEN environment variable in the build process for greater robustness.
  * Changed the base image for the release stage to enhance compatibility.
  * Added the jq package to the dependency installation process.
  * Made minor adjustments to script error handling and variable reference styles for consistency.
  * Enhanced Docker build caching by expanding cache scope to include dependency files and adjusted cache usage in test workflows.
  * Modified dependency installation to include recommended packages for improved build completeness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->