### PR TITLE
Fix GitHub commit passing, UI build and cache for different purposes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
           build-args: |
             NODE_ENV=production
             VERSION=${{ github.ref_name }}
-            GITHUB_SHA=${{ steps.git.outputs.short_sha }}
+            COMMIT_SHA=${{ steps.git.outputs.short_sha }}
 
   dockle:
     name: Dockle Container Analysis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,18 +117,43 @@ jobs:
             ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}' || '' }}
             ${{ github.event_name != 'schedule' && 'type=sha' || '' }}
 
+      - name: Prepare build arguments
+        id: args
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "short_sha=$(git rev-parse --short HEAD)" | tee -a $GITHUB_OUTPUT
+
+          token=$(curl -fsSL --retry 2 --retry-delay 5 --retry-max-time 60 \
+            -u "${{ env.DOCKER_USERNAME }}:${{ env.DOCKER_PASSWORD }}" \
+            "https://auth.docker.io/token?service=registry.docker.io&scope=repository:photoview/dependencies:pull" \
+            | jq -r .token)
+          echo "deps_tag=$(curl -fsSL --retry 2 --retry-delay 5 --retry-max-time 60 \
+            -H "Authorization: Bearer ${token}" \
+            "https://registry.hub.docker.com/v2/repositories/photoview/dependencies/tags?page_size=100" \
+            | jq -r '
+              .results
+              | map(select(.name | startswith("sha-")))
+              | sort_by(.tag_last_pushed)
+              | reverse
+              | .[0].name
+            ')" | tee -a $GITHUB_OUTPUT
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context:     .
+          target:      release
           sbom:        true
           provenance:  mode=max
           platforms:   ${{ env.PLATFORMS }}
           pull:        true
           push:        ${{ env.IS_PUSHING_IMAGES }}
           tags:        ${{ steps.docker_meta.outputs.tags }}
-          labels:      ${{ steps.docker_meta.outputs.labels }}
           annotations: ${{ steps.docker_meta.outputs.annotations }}
+          labels: |
+            ${{ steps.docker_meta.outputs.labels }}
+            photoview.dependencies.tag: ${{ steps.args.outputs.deps_tag }}
           cache-from: |
             type=gha,scope=ui-${{ hashFiles('ui/package-lock.json') }}
             type=gha,scope=test-api-${{ hashFiles('api/go.sum', 'scripts/install_*.sh', 'dependencies/*') }}
@@ -138,7 +163,8 @@ jobs:
           build-args: |
             NODE_ENV=production
             VERSION=${{ github.ref_name }}
-            GITHUB_SHA=${{ github.sha }}
+            GITHUB_SHA=${{ steps.args.outputs.short_sha }}
+            DEPS_TAG=${{ steps.args.outputs.deps_tag }}
 
   dockle:
     name: Dockle Container Analysis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --all
-          echo "short_sha=$(git rev-parse --short HEAD)" | tee -a $GITHUB_OUTPUT
+          echo "COMMIT_SHORT_SHA=$(git rev-parse --short HEAD)" | tee -a $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -144,7 +144,7 @@ jobs:
           build-args: |
             NODE_ENV=production
             VERSION=${{ github.ref_name }}
-            COMMIT_SHA=${{ steps.git.outputs.short_sha }}
+            COMMIT_SHA=${{ steps.git.outputs.COMMIT_SHORT_SHA }}
 
   dockle:
     name: Dockle Container Analysis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,13 +123,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "short_sha=$(git rev-parse --short HEAD)" | tee -a $GITHUB_OUTPUT
-
-          token=$(curl -fsSL --retry 2 --retry-delay 5 --retry-max-time 60 \
-            -u "${{ env.DOCKER_USERNAME }}:${{ env.DOCKER_PASSWORD }}" \
-            "https://auth.docker.io/token?service=registry.docker.io&scope=repository:photoview/dependencies:pull" \
-            | jq -r .token)
           echo "deps_tag=$(curl -fsSL --retry 2 --retry-delay 5 --retry-max-time 60 \
-            -H "Authorization: Bearer ${token}" \
             "https://registry.hub.docker.com/v2/repositories/photoview/dependencies/tags?page_size=100" \
             | jq -r '
               .results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,7 +158,7 @@ jobs:
             NODE_ENV=production
             VERSION=${{ github.ref_name }}
             GITHUB_SHA=${{ steps.args.outputs.short_sha }}
-            DEPS_TAG=${{ steps.args.outputs.deps_tag }}
+            DEPS_IMG=photoview/dependencies:${{ steps.args.outputs.deps_tag }}
 
   dockle:
     name: Dockle Container Analysis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,14 +130,15 @@ jobs:
           labels:      ${{ steps.docker_meta.outputs.labels }}
           annotations: ${{ steps.docker_meta.outputs.annotations }}
           cache-from: |
-            type=gha,scope=test-ui-${{ hashFiles('ui/package-lock.json') }}
+            type=gha,scope=ui-${{ hashFiles('ui/package-lock.json') }}
             type=gha,scope=test-api-${{ hashFiles('api/go.sum', 'scripts/install_*.sh', 'dependencies/*') }}
           cache-to: |
-            type=gha,mode=max,scope=test-ui-${{ hashFiles('ui/package-lock.json') }}
+            type=gha,mode=max,scope=ui-${{ hashFiles('ui/package-lock.json') }}
             type=gha,mode=max,scope=test-api-${{ hashFiles('api/go.sum', 'scripts/install_*.sh', 'dependencies/*') }}
           build-args: |
             NODE_ENV=production
             VERSION=${{ github.ref_name }}
+            GITHUB_SHA=${{ github.sha }}
 
   dockle:
     name: Dockle Container Analysis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,12 @@ jobs:
           ref: ${{ matrix.tags.ref }}
 
       - name: Fetch branches
-        run: git fetch --all
+        id: git
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --all
+          echo "short_sha=$(git rev-parse --short HEAD)" | tee -a $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -117,22 +122,6 @@ jobs:
             ${{ github.event_name != 'schedule' && 'type=semver,pattern={{major}}' || '' }}
             ${{ github.event_name != 'schedule' && 'type=sha' || '' }}
 
-      - name: Prepare build arguments
-        id: args
-        shell: bash
-        run: |
-          set -euo pipefail
-          echo "short_sha=$(git rev-parse --short HEAD)" | tee -a $GITHUB_OUTPUT
-          echo "deps_tag=$(curl -fsSL --retry 2 --retry-delay 5 --retry-max-time 60 \
-            "https://registry.hub.docker.com/v2/repositories/photoview/dependencies/tags?page_size=100" \
-            | jq -r '
-              .results
-              | map(select(.name | startswith("sha-")))
-              | sort_by(.tag_last_pushed)
-              | reverse
-              | .[0].name
-            ')" | tee -a $GITHUB_OUTPUT
-
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -144,10 +133,8 @@ jobs:
           pull:        true
           push:        ${{ env.IS_PUSHING_IMAGES }}
           tags:        ${{ steps.docker_meta.outputs.tags }}
+          labels:      ${{ steps.docker_meta.outputs.labels }}
           annotations: ${{ steps.docker_meta.outputs.annotations }}
-          labels: |
-            ${{ steps.docker_meta.outputs.labels }}
-            photoview.dependencies.tag: ${{ steps.args.outputs.deps_tag }}
           cache-from: |
             type=gha,scope=ui-${{ hashFiles('ui/package-lock.json') }}
             type=gha,scope=test-api-${{ hashFiles('api/go.sum', 'scripts/install_*.sh', 'dependencies/*') }}
@@ -157,8 +144,7 @@ jobs:
           build-args: |
             NODE_ENV=production
             VERSION=${{ github.ref_name }}
-            GITHUB_SHA=${{ steps.args.outputs.short_sha }}
-            DEPS_IMG=photoview/dependencies:${{ steps.args.outputs.deps_tag }}
+            GITHUB_SHA=${{ steps.git.outputs.short_sha }}
 
   dockle:
     name: Dockle Container Analysis

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,6 +112,7 @@ jobs:
         target:     ui
         tags:       photoview/ui
         cache-from: type=gha,scope=test-ui-${{ hashFiles('ui/package-lock.json') }}
+        cache-to:   type=gha,mode=max,scope=test-ui-${{ hashFiles('ui/package-lock.json') }}
         build-args: |
           NODE_ENV=testing
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -134,7 +134,7 @@ RUN find /app/ui/assets -type f -name "SettingsPage.*.js" \
     -exec sed -i "s/=\"-=<GitHub-CI-commit-sha-placeholder>=-\";/=\"${GITHUB_SHA:-unknown_commit}\";/g" {} \;
 # TEMP verification commands:
 RUN grep -Hn '="[^"]*";' /app/ui/assets/SettingsPage.*.js | grep "${GITHUB_SHA:-unknown_commit}" \
-    grep -Hn '="-=<GitHub-CI-commit-sha-placeholder>=-";' /app/ui/assets/SettingsPage.*.js
+    && grep -Hn '="-=<GitHub-CI-commit-sha-placeholder>=-";' /app/ui/assets/SettingsPage.*.js || true
 
 WORKDIR /home/photoview
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -131,7 +131,10 @@ COPY --from=api /app/api/photoview /app/photoview
 # This is a w/a for letting the UI build stage to be cached
 # and not rebuilt every new commit because of the build_arg value change.
 RUN find /app/ui/assets -type f -name "SettingsPage.*.js" \
-    -exec sed -i 's/="-=<GitHub-CI-commit-sha-placeholder>=-";/="${GITHUB_SHA:-unknown_commit}";/g' {} \;
+    -exec sed -i "s/=\"-=<GitHub-CI-commit-sha-placeholder>=-\";/=\"${GITHUB_SHA:-unknown_commit}\";/g" {} \; \
+    # TEMP verification commands:
+    grep -Hn '="[^"]*";' /app/ui/assets/SettingsPage.*.js | grep "${GITHUB_SHA:-unknown_commit}" \
+    grep -Hn '="-=<GitHub-CI-commit-sha-placeholder>=-";' /app/ui/assets/SettingsPage.*.js
 
 WORKDIR /home/photoview
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ WORKDIR /app/ui
 
 COPY ui/package.json ui/package-lock.json /app/ui/
 RUN if [ "$NODE_ENV" = "production" ]; then \
-    echo "Installing production dependencies only..."; \
-    npm ci --omit=dev; \
+        echo "Installing production dependencies only..."; \
+        npm ci --omit=dev; \
     else \
-    echo "Installing all dependencies..."; \
-    npm ci; \
+        echo "Installing all dependencies..."; \
+        npm ci; \
     fi
 
 COPY ui/ /app/ui
@@ -87,8 +87,8 @@ RUN export $(cat /env) \
     && sed -i 's/-march=native//g' ${GOPATH}/pkg/mod/github.com/!kagami/go-face*/face.go \
     # Build dependencies that use CGO
     && go install \
-    github.com/mattn/go-sqlite3 \
-    github.com/Kagami/go-face
+        github.com/mattn/go-sqlite3 \
+        github.com/Kagami/go-face
 
 COPY api /app/api
 # Split values in `/env`
@@ -129,9 +129,9 @@ COPY --from=ui /app/ui/dist /app/ui
 COPY --from=api /app/api/photoview /app/photoview
 # This is a w/a for letting the UI build stage to be cached
 # and not rebuilt every new commit because of the build_arg value change.
-ARG COMMIT_SHA=?commit?
+ARG COMMIT_SHA=NoCommit
 RUN find /app/ui/assets -type f -name "SettingsPage.*.js" \
-    -exec sed -i "s/=\"-=<GitHub-CI-commit-sha-placeholder>=-\";/=\"${COMMIT_SHA}\";/g" {} \;
+        -exec sed -i "s/=\"-=<GitHub-CI-commit-sha-placeholder>=-\";/=\"${COMMIT_SHA}\";/g" {} \;
 
 WORKDIR /home/photoview
 
@@ -147,8 +147,8 @@ EXPOSE ${PHOTOVIEW_LISTEN_PORT}
 
 HEALTHCHECK --interval=60s --timeout=10s \
     CMD curl --fail http://localhost:${PHOTOVIEW_LISTEN_PORT}/api/graphql \
-    -X POST -H 'Content-Type: application/json' \
-    --data-raw '{"operationName":"CheckInitialSetup","variables":{},"query":"query CheckInitialSetup { siteInfo { initialSetup }}"}' \
+        -X POST -H 'Content-Type: application/json' \
+        --data-raw '{"operationName":"CheckInitialSetup","variables":{},"query":"query CheckInitialSetup { siteInfo { initialSetup }}"}' \
     || exit 1
 
 USER photoview

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ WORKDIR /app/ui
 
 COPY ui/package.json ui/package-lock.json /app/ui/
 RUN if [ "$NODE_ENV" = "production" ]; then \
+    echo "Installing production dependencies only..."; \
     npm ci --omit=dev; \
     else \
+    echo "Installing all dependencies..."; \
     npm ci; \
     fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -131,9 +131,9 @@ COPY --from=api /app/api/photoview /app/photoview
 # This is a w/a for letting the UI build stage to be cached
 # and not rebuilt every new commit because of the build_arg value change.
 RUN find /app/ui/assets -type f -name "SettingsPage.*.js" \
-    -exec sed -i "s/=\"-=<GitHub-CI-commit-sha-placeholder>=-\";/=\"${GITHUB_SHA:-unknown_commit}\";/g" {} \; \
-    # TEMP verification commands:
-    grep -Hn '="[^"]*";' /app/ui/assets/SettingsPage.*.js | grep "${GITHUB_SHA:-unknown_commit}" \
+    -exec sed -i "s/=\"-=<GitHub-CI-commit-sha-placeholder>=-\";/=\"${GITHUB_SHA:-unknown_commit}\";/g" {} \;
+# TEMP verification commands:
+RUN grep -Hn '="[^"]*";' /app/ui/assets/SettingsPage.*.js | grep "${GITHUB_SHA:-unknown_commit}" \
     grep -Hn '="-=<GitHub-CI-commit-sha-placeholder>=-";' /app/ui/assets/SettingsPage.*.js
 
 WORKDIR /home/photoview

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN export BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ'); \
 ### Build API ###
 FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.24-bookworm AS api
 ARG TARGETPLATFORM
-ARG DEPS_TAG=latest
+ARG DEPS_IMG=photoview/dependencies:latest
 
 # See for details: https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
@@ -65,7 +65,7 @@ RUN chmod +x /app/scripts/*.sh \
     && /app/scripts/install_build_dependencies.sh \
     && /app/scripts/install_runtime_dependencies.sh
 
-COPY --from=photoview/dependencies:${DEPS_TAG} /artifacts.tar.gz /dependencies/
+COPY --from=${DEPS_IMG} /artifacts.tar.gz /dependencies/
 # Split values in `/env`
 # hadolint ignore=SC2046
 RUN export $(cat /env) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN export BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ'); \
 ### Build API ###
 FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.24-bookworm AS api
 ARG TARGETPLATFORM
+ARG DEPS_TAG
 
 # See for details: https://github.com/hadolint/hadolint/wiki/DL4006
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
@@ -64,7 +65,8 @@ RUN chmod +x /app/scripts/*.sh \
     && /app/scripts/install_build_dependencies.sh \
     && /app/scripts/install_runtime_dependencies.sh
 
-COPY --from=photoview/dependencies /artifacts.tar.gz /dependencies/
+ENV DEPS_TAG=${DEPS_TAG:-latest}
+COPY --from=photoview/dependencies:${DEPS_TAG} /artifacts.tar.gz /dependencies/
 # Split values in `/env`
 # hadolint ignore=SC2046
 RUN export $(cat /env) \


### PR DESCRIPTION
During today's testing of the new queue, I noticed that the commit hash wasn't correctly passed to the UI build after my previous Docker build refactoring. Unfortunately, it is not possible to fix it in a straightforward way while keeping the UI build stage cached. So I had to implement a workaround with a static placeholder on the build stage and its replacement on the final release preparation steps.
Also, I noticed that the `NODE_ENV` build arg is always different for build and test workflows, so the build cache (even with the same key) won't be used. That is why I renamed the build cache for the UI part and added a `cache-to` parameter for UI testing.
Finally, as we always know the NODE_ENV value when we build the image, I replaced the static `npm ci` command with a conditional one, which installs dev-dependencies only for non-production builds - this is much more secure, and a bit faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build caching for UI components in continuous integration workflows, resulting in faster and more efficient builds.
  * Updated the Docker build process to inject the Git commit SHA into the UI at release time, enhancing traceability of deployed versions.
  * Optimized dependency installation during UI builds for better performance in production and development environments.
  * Enhanced build workflows to dynamically fetch branches and use commit SHAs, improving build consistency and image labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->