### PR TITLE
Auto-orient image during processing

### DIFF
--- a/api/scanner/media_encoding/executable_worker/magickwand.go
+++ b/api/scanner/media_encoding/executable_worker/magickwand.go
@@ -44,6 +44,10 @@ func (cli *MagickWand) EncodeJpeg(inputPath string, outputPath string, jpegQuali
 		return fmt.Errorf("ImagickWand read %q error: %w", inputPath, err)
 	}
 
+	if err := wand.AutoOrientImage(); err != nil {
+		return fmt.Errorf("ImagickWand auto-orient %q error: %w", inputPath, err)
+	}
+
 	if err := wand.SetFormat("JPEG"); err != nil {
 		return fmt.Errorf("ImagickWand set JPEG format for %q error: %w", inputPath, err)
 	}
@@ -73,6 +77,10 @@ func (cli *MagickWand) GenerateThumbnail(inputPath string, outputPath string, wi
 
 	if err := wand.ThumbnailImage(width, height); err != nil {
 		return fmt.Errorf("ImagickWand generate thumbnail for %q error: %w", inputPath, err)
+	}
+
+	if err := wand.AutoOrientImage(); err != nil {
+		return fmt.Errorf("ImagickWand auto-orient %q error: %w", inputPath, err)
 	}
 
 	if err := wand.SetFormat("JPEG"); err != nil {


### PR DESCRIPTION
I've noticed an image orientation bug while making thumbnails:

![SCR-20250709-pohz](https://github.com/user-attachments/assets/2937ff82-c50b-4f8d-873a-42c65a5461a2)
![SCR-20250709-podu](https://github.com/user-attachments/assets/1d17a04b-1a4f-44f2-88a3-4e1c1ae2cb19)

Which causes these artifacts after clicking on them:

![SCR-20250709-poqq](https://github.com/user-attachments/assets/2a54fa11-e26a-4dd7-8e7f-bf1cfb24a4a3)
![SCR-20250709-ponb](https://github.com/user-attachments/assets/9b8f0aa7-4292-4843-8158-817246b632bd)

So, I added an image auto-orientation step for both the Thumbnails and Encode functions. It works stably now, and all images are oriented correctly.