### PR TITLE
Non-fork face detection, avoiding a race condition.

### DIFF
--- a/api/scanner/scanner_tasks/face_detection_task.go
+++ b/api/scanner/scanner_tasks/face_detection_task.go
@@ -18,14 +18,13 @@ func (t FaceDetectionTask) AfterProcessMedia(ctx scanner_task.TaskContext, media
 	didProcess := len(updatedURLs) > 0
 
 	if didProcess && mediaData.Media.Type == models.MediaTypePhoto {
-		go func(media *models.Media) {
-			if face_detection.GlobalFaceDetector == nil {
-				return
-			}
-			if err := face_detection.GlobalFaceDetector.DetectFaces(ctx.GetDB(), media); err != nil {
-				scanner_utils.ScannerError(ctx, "Error detecting faces in image (%s): %s", media.Path, err)
-			}
-		}(mediaData.Media)
+		media := mediaData.Media
+		if face_detection.GlobalFaceDetector == nil {
+			return nil
+		}
+		if err := face_detection.GlobalFaceDetector.DetectFaces(ctx.GetDB(), media); err != nil {
+			scanner_utils.ScannerError(ctx, "Error detecting faces in image (%s): %s", media.Path, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Face detection task is run by `scanner_queue`, which manages a group of workers to run tasks. The worker number controls the number of concurrent tasks. Previously, since the face detection is run by `go func()`, it escapes with this limitation. This PR fixes this escape.

Current performance of `RunScannerOnUser()` in `scanner_test`:

- MySQL: [RunScannerOnUser(user(id:1)) took 3.656870134s.](https://github.com/photoview/photoview/actions/runs/16179648287/job/45673067158?pr=1243#step:6:12426)
- Postgres: [RunScannerOnUser(user(id:1)) took 3.556388349s.](https://github.com/photoview/photoview/actions/runs/16179648287/job/45673067164?pr=1243#step:6:10941)
- SQLite: [RunScannerOnUser(user(id:1)) took 4.25395262s.](https://github.com/photoview/photoview/actions/runs/16179648287/job/45673067160?pr=1243#step:6:11955)

On my laptop:

- SQLite: (master)1.779806718s -> (this PR)2.305311019s
- MySQL: (master)1.629139008s -> (this PR)1.848778465s
- Postgres: (master)1.630148587s -> (this PR)1.805706042s

Compared to master, it takes a little bit longer, as counting the time spent on face detection when calls `RunScannerXXX()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Improved the reliability of face detection by running it synchronously during media processing.
  * Simplified face detection tests by replacing asynchronous waiting with immediate verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->