### PR TITLE
Fix failed build for `v2.4.0` version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context:     .
-          target:      release
+          #target:      release # Uncomment brefore releasing the new version, as the 2.4.0 doesn't have this target.
           sbom:        true
           provenance:  mode=max
           platforms:   ${{ env.PLATFORMS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context:     .
-          #target:      release # Uncomment brefore releasing the new version, as the 2.4.0 doesn't have this target.
+          #target:      release # Uncomment before releasing the new version, as the 2.4.0 doesn't have this target.
           sbom:        true
           provenance:  mode=max
           platforms:   ${{ env.PLATFORMS }}


### PR DESCRIPTION
I forgot that the `v2.4.0` doesn't have the `release` target in the Dockerfile.
This PR fixes the https://github.com/photoview/photoview/actions/runs/16185082651/job/45689053391#step:9:268 failure of the `v2.4.0` scheduled build by commenting the `target` parameter till we prepare the new release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build process to improve compatibility with version 2.4.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->