### PR TITLE
Add missing `os.exit()` wrapper to the test call.

### DIFF
--- a/api/scanner/media_type/media_type_test.go
+++ b/api/scanner/media_type/media_type_test.go
@@ -1,13 +1,14 @@
 package media_type
 
 import (
+	"os"
 	"testing"
 
 	"github.com/photoview/photoview/api/test_utils"
 )
 
 func TestMain(m *testing.M) {
-	test_utils.UnitTestRun(m)
+	os.Exit(test_utils.UnitTestRun(m))
 }
 
 type boolImage bool


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test process to ensure correct exit status is reported after running tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->