### PR TITLE
Fix: Exif parsers should accept longtitude up to 180 degrees

### DIFF
--- a/api/scanner/exif/exif_parser_external.go
+++ b/api/scanner/exif/exif_parser_external.go
@@ -81,7 +81,7 @@ func extractValidGpsData(fileInfo *exiftool.FileMetadata, mediaPath string) (*fl
 	// GPS data validation
 	if (GPSLat != nil && math.Abs(*GPSLat) > 90) || (GPSLong != nil && math.Abs(*GPSLong) > 180) {
 		log.Printf(
-			"Incorrect GPS data in the %s Exif data: %f, %f, while expected latitude between '-90' and '90', and longtitude between '-180' and '180'. Ignoring GPS data.",
+			"Incorrect GPS data in the %s Exif data: %f, %f, while expected latitude between '-90' and '90', and longitude between '-180' and '180'. Ignoring GPS data.",
 			mediaPath, *GPSLat, *GPSLong)
 		return nil, nil
 	}

--- a/api/scanner/exif/exif_parser_external.go
+++ b/api/scanner/exif/exif_parser_external.go
@@ -79,9 +79,9 @@ func extractValidGpsData(fileInfo *exiftool.FileMetadata, mediaPath string) (*fl
 	}
 
 	// GPS data validation
-	if (GPSLat != nil && math.Abs(*GPSLat) > 90) || (GPSLong != nil && math.Abs(*GPSLong) > 90) {
+	if (GPSLat != nil && math.Abs(*GPSLat) > 90) || (GPSLong != nil && math.Abs(*GPSLong) > 180) {
 		log.Printf(
-			"Incorrect GPS data in the %s Exif data: %f, %f, while expected values between '-90' and '90'. Ignoring GPS data.",
+			"Incorrect GPS data in the %s Exif data: %f, %f, while expected latitude between '-90' and '90', and longtitude between '-180' and '180'. Ignoring GPS data.",
 			mediaPath, *GPSLat, *GPSLong)
 		return nil, nil
 	}

--- a/api/scanner/exif/exif_parser_internal.go
+++ b/api/scanner/exif/exif_parser_internal.go
@@ -147,7 +147,7 @@ func (p internalExifParser) ParseExif(mediaPath string) (returnExif *models.Medi
 		if math.Abs(lat) > 90 || math.Abs(long) > 180 {
 			returnExif = &newExif
 			log.Printf(
-				"Incorrect GPS data in the %s Exif data: %f, %f, while expected latitude between '-90' and '90', and longtitude between '-180' and '180'. Ignoring GPS data.",
+				"Incorrect GPS data in the %s Exif data: %f, %f, while expected latitude between '-90' and '90', and longitude between '-180' and '180'. Ignoring GPS data.",
 				mediaPath, long, lat)
 			return
 		} else {

--- a/api/scanner/exif/exif_parser_internal.go
+++ b/api/scanner/exif/exif_parser_internal.go
@@ -144,10 +144,10 @@ func (p internalExifParser) ParseExif(mediaPath string) (returnExif *models.Medi
 
 	lat, long, err := exifTags.LatLong()
 	if err == nil {
-		if math.Abs(lat) > 90 || math.Abs(long) > 90 {
+		if math.Abs(lat) > 90 || math.Abs(long) > 180 {
 			returnExif = &newExif
 			log.Printf(
-				"Incorrect GPS data in the %s Exif data: %f, %f, while expected values between '-90' and '90'. Ignoring GPS data.",
+				"Incorrect GPS data in the %s Exif data: %f, %f, while expected latitude between '-90' and '90', and longtitude between '-180' and '180'. Ignoring GPS data.",
 				mediaPath, long, lat)
 			return
 		} else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected validation for GPS longitude in EXIF data to ensure proper handling of valid coordinate ranges.
  * Updated warning messages to accurately reflect the correct valid ranges for latitude and longitude.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->