### PR TITLE
Update macos local development dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Then run the following commands:
 # Optional: Set the compiler environment in Debian/Ubuntu
 $ source ./scripts/set_compiler_env.sh
 # Set the compiler environment with `homebrew`
-$ export CPLUS_INCLUDE_PATH="$(brew --prefix)/opt/jpeg/include:$(brew --prefix)/opt/dlib/include"
+$ export CPLUS_INCLUDE_PATH="$(brew --prefix)/opt/jpeg/include:$(brew --prefix)/opt/dlib/include:${CPLUS_INCLUDE_PATH:-}"
 $ export C_INCLUDE_PATH="$(brew --prefix)/opt/libmagic/include:${C_INCLUDE_PATH:-}"
 $ export DYLD_LIBRARY_PATH="$(brew --prefix)/opt/jpeg/lib:$(brew --prefix)/opt/dlib/lib:$(brew --prefix)/opt/libmagic/lib:${DYLD_LIBRARY_PATH:-}"
 $ export LIBRARY_PATH="$(brew --prefix)/opt/jpeg/lib:$(brew --prefix)/opt/dlib/lib:$(brew --prefix)/opt/libmagic/lib:${LIBRARY_PATH:-}"


### PR DESCRIPTION
I'm trying to contribute and decided to go the local development route for now (macos) instead of using the docker development environment. 

It looks like the `libmagic` and `imagemagick` formulae were missing, and the corresponding include/lib paths for `libmagic`.

I also needed to configure CGO to allow the -Xpreprocessor compiler flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated macOS setup instructions to include installation of additional dependencies.
  * Modified environment variable setup steps to reflect new paths and variables for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->