### PR TITLE
Add scrollbar to people sidebar section

### DIFF
--- a/ui/src/components/sidebar/MediaSidebar/MediaSidebarPeople.tsx
+++ b/ui/src/components/sidebar/MediaSidebar/MediaSidebarPeople.tsx
@@ -200,7 +200,7 @@ const MediaSidebarPeople = ({ media }: MediaSidebarFacesProps) => {
   const { t } = useTranslation()
 
   const faceElms = (media.faces ?? []).map((face, i) => (
-    <MediaSidebarPerson key={face.id} face={face} menuFlipped={i == 0} />
+    <MediaSidebarPerson key={face.id} face={face} menuFlipped={i % 3 == 0} />
   ))
 
   if (faceElms.length == 0) return null


### PR DESCRIPTION
If there are more than a few people recognized in a picture it is currently not possible to see all the faces on a non-mobile platform.

<img width="410" height="191" alt="Screenshot 2025-08-17 at 10 52 27 PM" src="https://github.com/user-attachments/assets/8b21d6ad-dfea-4aa8-b630-63073ca1be58" />


This is how it looks on chrome on macos after moving `overflow-x-auto` to the `ul` element and removing the height and margin modifications:

<img width="424" height="184" alt="Screenshot 2025-08-17 at 11 01 38 PM" src="https://github.com/user-attachments/assets/47344fcf-2062-4717-b725-80fe4c4b2122" />


I'm not sure why the adjustments to margin/height were there (maybe to increase scroll area? - note that scrolling did work on mobile browser by dragging but no scroll bar was shown). I also think the scrollbar width was set to none to not have it take up space on a smaller device, but I believe that now the general guidance is to let the platform hide the scrollbar if it chooses to do so. I'm a total front end/styling noob though so if I'm totally off base please let me know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Style
  * People section in the media sidebar now uses a 3-column grid instead of horizontal scrolling.
  * Avatars and details are stacked vertically and centered for clearer scanning.
  * Removed extra spacer/scroll area for a cleaner, more compact layout.
  * Improved spacing, alignment, and menu placement for more consistent, at-a-glance browsing of people.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->