### PR TITLE
Avoid all os.Exit and log.Fatal

### DIFF
--- a/api/test_utils/integration_setup.go
+++ b/api/test_utils/integration_setup.go
@@ -16,11 +16,22 @@ import (
 var test_dbm TestDBManager = TestDBManager{}
 
 func UnitTestRun(m *testing.M) {
+	exitCode := 0
+	defer func() {
+		os.Exit(exitCode)
+	}()
+
 	flag.Parse()
-	os.Exit(m.Run())
+
+	exitCode = m.Run()
 }
 
 func IntegrationTestRun(m *testing.M) {
+	exitCode := 0
+	defer func() {
+		os.Exit(exitCode)
+	}()
+
 	flag.Parse()
 
 	if flags.Database {
@@ -38,7 +49,7 @@ func IntegrationTestRun(m *testing.M) {
 	terminateWorkers := executable_worker.Initialize()
 	defer terminateWorkers()
 
-	os.Exit(m.Run())
+	exitCode = m.Run()
 }
 
 func FilesystemTest(t *testing.T) {

--- a/api/test_utils/integration_setup.go
+++ b/api/test_utils/integration_setup.go
@@ -16,7 +16,7 @@ import (
 var test_dbm TestDBManager = TestDBManager{}
 
 func UnitTestRun(m *testing.M) {
-	exitCode := 0
+	exitCode := 1
 	defer func() {
 		os.Exit(exitCode)
 	}()
@@ -27,7 +27,7 @@ func UnitTestRun(m *testing.M) {
 }
 
 func IntegrationTestRun(m *testing.M) {
-	exitCode := 0
+	exitCode := 1
 	defer func() {
 		os.Exit(exitCode)
 	}()

--- a/api/utils/endpoints.go
+++ b/api/utils/endpoints.go
@@ -32,12 +32,12 @@ func ApiListenUrl() *url.URL {
 
 	listenPort, err := strconv.Atoi(listenPortStr)
 	if err != nil {
-		log.Fatalf("%s must be a number: '%s'\n%s", EnvListenPort.GetName(), listenPortStr, err)
+		log.Panicf("%s must be a number: '%s'\n%s", EnvListenPort.GetName(), listenPortStr, err)
 	}
 
 	apiUrl, err := url.Parse(fmt.Sprintf("http://%s:%d", listenAddr, listenPort))
 	if err != nil {
-		log.Fatalf("Could not format api url: %s", err)
+		log.Panicf("Could not format api url: %s", err)
 	}
 	apiUrl.Path = apiPrefix
 
@@ -56,7 +56,7 @@ func ApiEndpointUrl() *url.URL {
 
 	apiEndpointURL, err := url.Parse(apiEndpointStr)
 	if err != nil {
-		log.Fatalf("ERROR: Environment variable %s is not a proper url (%s)",
+		log.Panicf("ERROR: Environment variable %s is not a proper url (%s)",
 			EnvAPIEndpoint.GetName(), EnvAPIEndpoint.GetValue())
 	}
 
@@ -75,7 +75,7 @@ func UiEndpointUrl() *url.URL {
 
 	uiEndpointURL, err := url.Parse(EnvUIEndpoint.GetValue())
 	if err != nil {
-		log.Fatalf("ERROR: Environment variable %s is not a proper url (%s)",
+		log.Panicf("ERROR: Environment variable %s is not a proper url (%s)",
 			EnvUIEndpoint.GetName(), EnvUIEndpoint.GetValue())
 	}
 

--- a/api/utils/endpoints.go
+++ b/api/utils/endpoints.go
@@ -32,12 +32,12 @@ func ApiListenUrl() *url.URL {
 
 	listenPort, err := strconv.Atoi(listenPortStr)
 	if err != nil {
-		log.Panicf("%s must be a number: '%s'\n%s", EnvListenPort.GetName(), listenPortStr, err)
+		log.Panicf("%q must be a number %q: %v", EnvListenPort.GetName(), listenPortStr, err)
 	}
 
 	apiUrl, err := url.Parse(fmt.Sprintf("http://%s:%d", listenAddr, listenPort))
 	if err != nil {
-		log.Panicf("Could not format api url: %s", err)
+		log.Panicf("Could not format api url: %v", err)
 	}
 	apiUrl.Path = apiPrefix
 
@@ -56,8 +56,8 @@ func ApiEndpointUrl() *url.URL {
 
 	apiEndpointURL, err := url.Parse(apiEndpointStr)
 	if err != nil {
-		log.Panicf("ERROR: Environment variable %s is not a proper url (%s)",
-			EnvAPIEndpoint.GetName(), EnvAPIEndpoint.GetValue())
+		log.Panicf("ERROR: Environment variable %s is not a proper url (%s): %v",
+			EnvAPIEndpoint.GetName(), EnvAPIEndpoint.GetValue(), err)
 	}
 
 	if shouldServeUI {
@@ -75,8 +75,8 @@ func UiEndpointUrl() *url.URL {
 
 	uiEndpointURL, err := url.Parse(EnvUIEndpoint.GetValue())
 	if err != nil {
-		log.Panicf("ERROR: Environment variable %s is not a proper url (%s)",
-			EnvUIEndpoint.GetName(), EnvUIEndpoint.GetValue())
+		log.Panicf("ERROR: Environment variable %s is not a proper url (%s): %v",
+			EnvUIEndpoint.GetName(), EnvUIEndpoint.GetValue(), err)
 	}
 
 	return uiEndpointURL

--- a/api/utils/utils.go
+++ b/api/utils/utils.go
@@ -23,7 +23,7 @@ func GenerateToken() string {
 
 		n, err := rand.Int(rand.Reader, charLen)
 		if err != nil {
-			log.Fatalf("Could not generate random number: %s\n", err)
+			log.Panicf("Could not generate random number: %s\n", err)
 		}
 		b[i] = charset[n.Int64()]
 	}

--- a/api/utils/utils.go
+++ b/api/utils/utils.go
@@ -23,7 +23,7 @@ func GenerateToken() string {
 
 		n, err := rand.Int(rand.Reader, charLen)
 		if err != nil {
-			log.Panicf("Could not generate random number: %s\n", err)
+			log.Panicf("Could not generate random number: %v", err)
 		}
 		b[i] = charset[n.Int64()]
 	}


### PR DESCRIPTION
`log.Fatal` calls `os.Exit(1)` internally. So remove them with `log.Panic` to avoid `os.Exit()`.

Fix #1269 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Improved runtime error handling and more explicit diagnostic messages to aid troubleshooting and reduce abrupt process termination.
- Tests
  - Test harness updated so cleanup reliably runs before process exit, yielding more consistent and predictable test outcomes.

No functional changes to user-facing features; these updates enhance stability, diagnostics, and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->