### PR TITLE
Set the new PostgreSQL version in dev-compose and API tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
           - 3306:3306
 
       postgres:
-        image: postgres:16-alpine
+        image: postgres:17-alpine
         env:
           POSTGRES_USER: photoview
           POSTGRES_PASSWORD: photosecret

--- a/dev-compose.yaml
+++ b/dev-compose.yaml
@@ -67,7 +67,7 @@ services:
       - "3306"
 
   postgres:
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     profiles:
       - postgres
     environment:


### PR DESCRIPTION
@googollee, I forgot to update the dev-compose and CI API tests job with the new PostgreSQL version, so here is a small PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the Postgres container to 17-alpine across development and automation environments for improved compatibility and security.

* **Tests**
  * CI test environment now runs against Postgres 17 to ensure consistency and future-proofing.

* **Notes**
  * No user-facing changes or behavior impacts expected.
  * Improves environment parity and reduces maintenance risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->