### PR TITLE
Bump the `hadolint/hadolint-action` in CI workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Lint Dockerfile
         id: lint
-        uses: hadolint/hadolint-action@v3.2.0
+        uses: hadolint/hadolint-action@v3.3.0
         continue-on-error: true
         with:
           dockerfile: Dockerfile
@@ -152,7 +152,7 @@ jobs:
           overwrite: true
 
       - name: Lint Dockerfile (sarif)
-        uses: hadolint/hadolint-action@v3.2.0
+        uses: hadolint/hadolint-action@v3.3.0
         id: lint-report
         continue-on-error: true
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the Dockerfile linting in CI to use the latest hadolint-action (v3.3.0) for both standard and SARIF reporting steps. This enhances rule coverage, consistency, and reliability of automated checks, helping catch issues earlier. No user-facing functionality or UI changes are included in this update; application behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->