### PR TITLE
Bump PostgreSQL version to 18

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: ['*']
+    branches: ["*"]
   pull_request:
     branches: [master]
 
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        database: ['sqlite', 'mysql', 'postgres']
+        database: ["sqlite", "mysql", "postgres"]
 
     services:
       mariadb:
@@ -33,7 +33,7 @@ jobs:
           - 3306:3306
 
       postgres:
-        image: postgres:17-alpine
+        image: postgres:18-alpine
         env:
           POSTGRES_USER: photoview
           POSTGRES_PASSWORD: photosecret

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ We provide limited support for the standard deployment scenarios on the platform
 
 - [SQLite](https://sqlite.org/): built-in DBMS, no additional service or maintenance required; lowest performance and no scalability.
 - [MariaDB](https://mariadb.org/) LTS version: default choice. Runs as an additional service; good balance between performance and maintenance effort.
-- [PostgreSQL](https://www.postgresql.org/) 16 and 17: typically the best performance. Runs as an additional service; requires slightly more maintenance.
+- [PostgreSQL](https://www.postgresql.org/) 18 and 17: typically the best performance. Runs as an additional service; requires slightly more maintenance.
 
 We support running Photoview with one of these DBMSs when used as a dedicated instance for Photoview only.
 If you share a DBMS among multiple services, our support is limited to SQL issues. DB management and connection-related

--- a/README.md
+++ b/README.md
@@ -29,12 +29,13 @@ corresponding example of the compose file: <https://github.com/photoview/photovi
 
 # ATTENTION to PostgreSQL users !!!
 
-We switched to PostgreSQL 17 on the `master` branch. PostgreSQL 17 will be the default recommended version
-for the next release (PostgreSQL 16 remains supported). If you follow `master`, please check the
+We switched to PostgreSQL 18 on the `master` branch. PostgreSQL 18 will be the default recommended version
+for the next release (PostgreSQL 17 remains supported). If you follow `master`, please check the
 [official PostgreSQL upgrade guide](https://www.postgresql.org/docs/current/upgrading.html), and:
 
 - For Docker users: please update your `docker-compose.yml` to match [docker-compose.example.yml](./docker-compose%20example/docker-compose.example.yml).
-- For direct host installations or external/shared PostgreSQL instances: please upgrade your PostgreSQL server and database manually to version 17 following PostgreSQL guidance.
+- Please pay attention to the DB volume mount point change inside the container: starting from version 18, the DB is mounted to the `/var/lib/postgresql`, while in earlier versions it was the `/var/lib/postgresql/data`.
+- For direct host installations or external/shared PostgreSQL instances: please upgrade your PostgreSQL server and database manually to version 18 following PostgreSQL guidance.
 
 Don't forget to back up your database before upgrading.
 

--- a/dev-compose.yaml
+++ b/dev-compose.yaml
@@ -67,7 +67,7 @@ services:
       - "3306"
 
   postgres:
-    image: postgres:17-alpine
+    image: postgres:18-alpine
     profiles:
       - postgres
     environment:

--- a/docker-compose example/docker-compose.example.yml
+++ b/docker-compose example/docker-compose.example.yml
@@ -165,7 +165,7 @@ services:
   ## It is an optional service to simplify the upgrade process. You can also upgrade PostgreSQL manually.
   ## It is safe to keep it enabled, as if it detects no upgrade is needed, it exits immediately.
 #   postgres-autoupgrade:
-#     image: pgautoupgrade/pgautoupgrade:17-alpine
+#     image: pgautoupgrade/pgautoupgrade:18-alpine
 #     hostname: pgsql-upg
 #     container_name: pgsql-upg
 #     restart: "no"
@@ -179,11 +179,11 @@ services:
 #       ## - "/host/folder:/container/folder"
 #       - "/etc/localtime:/etc/localtime:ro" ## use local time from host
 #       - "/etc/timezone:/etc/timezone:ro"   ## use timezone from host
-#       - "${HOST_PHOTOVIEW_LOCATION}/database/postgres:/var/lib/postgresql/data" ## DO NOT REMOVE
+#       - "${HOST_PHOTOVIEW_LOCATION}/database/postgres:/var/lib/postgresql" ## DO NOT REMOVE
 
-  ## Uncomment the `postgres` service if PHOTOVIEW_DATABASE_DRIVER is set to `postgres` in the .env
+## Uncomment the `postgres` service if PHOTOVIEW_DATABASE_DRIVER is set to `postgres` in the .env
 #  postgres:
-#    image: postgres:17-alpine
+#    image: postgres:18-alpine
 #    labels:
 #      - "com.centurylinklabs.watchtower.enable=true"
 #    hostname: photoview-pgsql
@@ -211,7 +211,7 @@ services:
 #      ## - "/host/folder:/container/folder"
 #      - "/etc/localtime:/etc/localtime:ro" ## use local time from host
 #      - "/etc/timezone:/etc/timezone:ro"   ## use timezone from host
-#      - "${HOST_PHOTOVIEW_LOCATION}/database/postgres:/var/lib/postgresql/data" ## DO NOT REMOVE
+#      - "${HOST_PHOTOVIEW_LOCATION}/database/postgres:/var/lib/postgresql" ## DO NOT REMOVE
 #    healthcheck:
 #      test: pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB
 #      interval: 1m

--- a/docker-compose example/docker-compose.example.yml
+++ b/docker-compose example/docker-compose.example.yml
@@ -159,7 +159,7 @@ services:
   ## Uncomment the `postgres-autoupgrade` service if you want to upgrade PostgreSQL automatically, or follow the
   ## official PostgreSQL upgrade guide https://www.postgresql.org/docs/current/upgrading.html manually.
   ## Don't forget to uncomment the 3 `depends_on` lines in the `postgres` service.
-  ## This service will upgrade the PostgreSQL database to the version 17.
+  ## This service will upgrade the PostgreSQL database to the version, specified in the `image` tag.
   ## Read more on the https://hub.docker.com/r/pgautoupgrade/pgautoupgrade
   ## Tip: Back up the Photoview data before autoupgrade to a new PostgreSQL version.
   ## It is an optional service to simplify the upgrade process. You can also upgrade PostgreSQL manually.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * None

* **Documentation**
  * Updated guidance to PostgreSQL 18, including new data directory path; clarified PostgreSQL 17 remains supported.

* **Chores**
  * Upgraded PostgreSQL images to 18-alpine across development, CI, and examples.
  * Adjusted Docker volume mount target to /var/lib/postgresql for PostgreSQL 18.
  * Updated autoupgrade image tags and minor YAML quoting/formatting tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->