### PR TITLE
Use mariadbcheck instead of mysqlcheck

### DIFF
--- a/docker-compose example/Makefile
+++ b/docker-compose example/Makefile
@@ -93,8 +93,8 @@ backup-pre:
 	mkdir -p ${HOST_PHOTOVIEW_BACKUP}
 	mkdir ${HOST_PHOTOVIEW_BACKUP}/`date +%Y-%m-%d`
 backup-mariadb:
-	$(DOCKER_COMPOSE) exec mariadb mysqlcheck -u root --password=${MARIADB_ROOT_PASSWORD} --check --check-upgrade --flush --process-views=YES --auto-repair --all-databases
-	$(DOCKER_COMPOSE) exec mariadb mysqlcheck -u root --password=${MARIADB_ROOT_PASSWORD} --optimize --flush --auto-repair --all-databases
+	$(DOCKER_COMPOSE) exec mariadb mariadbcheck -u root --password=${MARIADB_ROOT_PASSWORD} --check --check-upgrade --flush --process-views=YES --auto-repair --all-databases
+	$(DOCKER_COMPOSE) exec mariadb mariadbcheck -u root --password=${MARIADB_ROOT_PASSWORD} --optimize --flush --auto-repair --all-databases
 	$(DOCKER_COMPOSE) exec mariadb mariadb-dump -u root --password=${MARIADB_ROOT_PASSWORD} -e -x --all-databases -- > ${HOST_PHOTOVIEW_BACKUP}/`date +%Y-%m-%d`/mariaDB_mysql_dump.sql
 	tar -cJf ${HOST_PHOTOVIEW_BACKUP}/`date +%Y-%m-%d`/mariaDB_mysql_dump.tar.xz ${HOST_PHOTOVIEW_BACKUP}/`date +%Y-%m-%d`/mariaDB_mysql_dump.sql --remove-files
 	@# 7zz a -mx=9 ${HOST_PHOTOVIEW_BACKUP}/`date +%Y-%m-%d`/mariaDB_mysql_dump.7z ${HOST_PHOTOVIEW_BACKUP}/`date +%Y-%m-%d`/mariaDB_mysql_dump.sql && rm ${HOST_PHOTOVIEW_BACKUP}/`date +%Y-%m-%d`/mariaDB_mysql_dump.sql


### PR DESCRIPTION
I just tried the backup command in the makefile (docker compose exxample) and got an error that `mysqlcheck` was not found. I found that the command needs to be replaced with `mariadbcheck`.

---

Use `mariadbcheck` instead of `mysqlcheck` in docker compose backup with containers based on Ubuntu 24.04.

https://packages.ubuntu.com/noble/amd64/mariadb-client/filelist

```bash
docker compose exec -it mariadb bash
root@photoview-mariadb:/#  cat /etc/os-release
PRETTY_NAME="Ubuntu 24.04.3 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04.3 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo

root@photoview-mariadb:/#  which mysqlcheck

root@photoview-mariadb:/#  which mariadbcheck
/usr/bin/mariadbcheck
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database backup operations to use MariaDB-compatible tooling, improving compatibility with modern MariaDB deployments and ensuring reliable backup functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->