### PR TITLE
Switch the WatchTower image source to the maintainable fork

### DIFF
--- a/docker-compose example/docker-compose.example.yml
+++ b/docker-compose example/docker-compose.example.yml
@@ -102,6 +102,8 @@ services:
       # - "${HOST_PHOTOVIEW_MEDIA_FAMILY}:/photos/Family:ro"
 
   ## Watchtower upgrades services automatically (optional)
+  ## WARNING: the automatic version upgrades may silently generate unexpected problems,
+  ##   so please periodically check the logs
   watchtower:
     image: nickfedor/watchtower:latest
     hostname: watchtower


### PR DESCRIPTION
The WatchTower project has been unmaintained for years and recently became incompatible with the latest Docker Engine version.
But there is [the well-maintained fork](https://github.com/nicholas-fedor/watchtower), with many GitHub stars and regular PRs. So, here is the PR to switch to it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose example to change the automatic-update service and add prominent warnings about potential silent issues from automatic version upgrades; users are advised to periodically review logs and monitor for unexpected behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->