### PR TITLE
Disable Dependabot checks for NPM dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,11 @@ updates:
       interval: "weekly"
     ignore:
       - dependency-name: "node"
+
+  # Disable automatic PRs with NPM updates
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule:
+      interval: "monthly"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
Since nobody maintains the UI part and the current UI code is so outdated (including the dependencies), I see no benefit in the Dependabot's PRs for the UI code.
This PR disables such PRs for the UI, while keeping them for all other ecosystems, where they are useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to set npm package updates to a monthly schedule with automatic updates disabled for the ui directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->