### PR TITLE
Add breadcrumb navigation to shared albums

### DIFF
--- a/api/graphql/resolvers/album.go
+++ b/api/graphql/resolvers/album.go
@@ -137,6 +137,10 @@ func (r *queryResolver) Album(ctx context.Context, id int, tokenCredentials *mod
 
 		if shareToken.Album != nil {
 			if *shareToken.AlbumID == id {
+				// Preload ParentAlbum for breadcrumb navigation
+				if err := db.Preload("ParentAlbum").First(shareToken.Album).Error; err != nil {
+					return nil, err
+				}
 				return shareToken.Album, nil
 			}
 
@@ -148,6 +152,10 @@ func (r *queryResolver) Album(ctx context.Context, id int, tokenCredentials *mod
 			}
 
 			if len(subAlbum) > 0 {
+				// Preload ParentAlbum for breadcrumb navigation
+				if err := db.Preload("ParentAlbum").First(subAlbum[0]).Error; err != nil {
+					return nil, err
+				}
 				return subAlbum[0], nil
 			}
 		}

--- a/api/graphql/resolvers/album.go
+++ b/api/graphql/resolvers/album.go
@@ -85,6 +85,51 @@ func (r *albumResolver) Path(ctx context.Context, obj *models.Album) ([]*models.
 	return actions.AlbumPath(r.DB(ctx), user, obj)
 }
 
+// PathForShare is the resolver for the pathForShare field.
+// Returns the breadcrumb path for shared albums, limited to the share root.
+func (r *albumResolver) PathForShare(ctx context.Context, obj *models.Album, token string, rootAlbumID int) ([]*models.Album, error) {
+	db := r.DB(ctx)
+
+	// Validate the share token exists and matches the rootAlbumID
+	var shareToken models.ShareToken
+	if err := db.Where("value = ?", token).First(&shareToken).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("share not found")
+		}
+		return nil, fmt.Errorf("failed to validate share token: %w", err)
+	}
+
+	// Verify that rootAlbumID matches the share token's album
+	if shareToken.AlbumID == nil || *shareToken.AlbumID != rootAlbumID {
+		return nil, errors.New("invalid root album for this share")
+	}
+
+	// If we're at the root album, return empty path
+	if obj.ID == rootAlbumID {
+		return make([]*models.Album, 0), nil
+	}
+
+	// Get all parent albums using existing GetParents function
+	parents, err := obj.GetParents(db, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter: exclude current album and stop at root album
+	var limitedPath []*models.Album
+	for _, p := range parents {
+		if p.ID == obj.ID {
+			continue
+		}
+		limitedPath = append(limitedPath, p)
+		if p.ID == rootAlbumID {
+			break
+		}
+	}
+
+	return limitedPath, nil
+}
+
 // Shares is the resolver for the shares field.
 func (r *albumResolver) Shares(ctx context.Context, obj *models.Album) ([]*models.ShareToken, error) {
 	var shareTokens []*models.ShareToken
@@ -137,10 +182,6 @@ func (r *queryResolver) Album(ctx context.Context, id int, tokenCredentials *mod
 
 		if shareToken.Album != nil {
 			if *shareToken.AlbumID == id {
-				// Preload ParentAlbum for breadcrumb navigation
-				if err := db.Preload("ParentAlbum").First(shareToken.Album).Error; err != nil {
-					return nil, err
-				}
 				return shareToken.Album, nil
 			}
 
@@ -152,10 +193,6 @@ func (r *queryResolver) Album(ctx context.Context, id int, tokenCredentials *mod
 			}
 
 			if len(subAlbum) > 0 {
-				// Preload ParentAlbum for breadcrumb navigation
-				if err := db.Preload("ParentAlbum").First(subAlbum[0]).Error; err != nil {
-					return nil, err
-				}
 				return subAlbum[0], nil
 			}
 		}

--- a/api/graphql/resolvers/album.graphql
+++ b/api/graphql/resolvers/album.graphql
@@ -27,6 +27,9 @@ type Album {
   "A breadcrumb list of all parent albums down to this one"
   path: [Album!]!
 
+  "A breadcrumb list of parent albums for shared album navigation, limited to the share root"
+  pathForShare(token: String!, rootAlbumId: ID!): [Album!]!
+
   "A list of share tokens pointing to this album, owned by the logged in user"
   shares: [ShareToken!]!
 }

--- a/ui/src/Pages/AllAlbumsPage/__generated__/getMyAlbums.ts
+++ b/ui/src/Pages/AllAlbumsPage/__generated__/getMyAlbums.ts
@@ -3,47 +3,47 @@
 // @generated
 // This file was automatically generated and should not be edited.
 
-import { OrderDirection } from './../../../__generated__/globalTypes'
+import { OrderDirection } from "./../../../__generated__/globalTypes";
 
 // ====================================================
 // GraphQL query operation: getMyAlbums
 // ====================================================
 
 export interface getMyAlbums_myAlbums_thumbnail_thumbnail {
-  __typename: 'MediaURL'
+  __typename: "MediaURL";
   /**
    * URL for previewing the image
    */
-  url: string
+  url: string;
 }
 
 export interface getMyAlbums_myAlbums_thumbnail {
-  __typename: 'Media'
-  id: string
+  __typename: "Media";
+  id: string;
   /**
    * URL to display the media in a smaller resolution
    */
-  thumbnail: getMyAlbums_myAlbums_thumbnail_thumbnail | null
+  thumbnail: getMyAlbums_myAlbums_thumbnail_thumbnail | null;
 }
 
 export interface getMyAlbums_myAlbums {
-  __typename: 'Album'
-  id: string
-  title: string
+  __typename: "Album";
+  id: string;
+  title: string;
   /**
    * An image in this album used for previewing this album
    */
-  thumbnail: getMyAlbums_myAlbums_thumbnail | null
+  thumbnail: getMyAlbums_myAlbums_thumbnail | null;
 }
 
 export interface getMyAlbums {
   /**
    * List of albums owned by the logged in user.
    */
-  myAlbums: getMyAlbums_myAlbums[]
+  myAlbums: getMyAlbums_myAlbums[];
 }
 
 export interface getMyAlbumsVariables {
-  orderBy?: string | null
-  orderDirection?: OrderDirection | null
+  orderBy?: string | null;
+  orderDirection?: OrderDirection | null;
 }

--- a/ui/src/Pages/SharePage/AlbumSharePage.tsx
+++ b/ui/src/Pages/SharePage/AlbumSharePage.tsx
@@ -9,7 +9,7 @@ import useOrderingParams from '../../hooks/useOrderingParams'
 import { shareAlbumQuery } from './__generated__/shareAlbumQuery'
 import useScrollPagination from '../../hooks/useScrollPagination'
 import PaginateLoader from '../../components/PaginateLoader'
-import { useNavigate, Link } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { BreadcrumbList } from '../../components/album/AlbumTitle'
 
 export const SHARE_ALBUM_QUERY = gql`
@@ -112,7 +112,6 @@ type AlbumSharePageProps = {
 
 const AlbumSharePage = ({ albumID, token, password, sharedRootAlbumId }: AlbumSharePageProps) => {
   const { t } = useTranslation()
-  const navigate = useNavigate()
 
   const urlParams = useURLParameters()
   const orderParams = useOrderingParams(urlParams)

--- a/ui/src/Pages/SharePage/SharePage.test.tsx
+++ b/ui/src/Pages/SharePage/SharePage.test.tsx
@@ -151,6 +151,7 @@ describe('load correct share page, based on graphql query', () => {
             id: '1',
             token,
             password,
+            rootAlbumId: '1',
             limit: 200,
             offset: 0,
             mediaOrderBy: 'date_shot',
@@ -162,6 +163,7 @@ describe('load correct share page, based on graphql query', () => {
             album: {
               id: '1',
               title: 'album_title',
+              pathForShare: [],
               subAlbums: [],
               thumbnail: {
                 url: 'https://photoview.example.com/album_thumbnail.jpg',
@@ -230,6 +232,7 @@ describe('load correct share page, based on graphql query', () => {
             id: subalbumID,
             token,
             password,
+            rootAlbumId: subalbumID,
             limit: 200,
             offset: 0,
             mediaOrderBy: 'date_shot',
@@ -241,6 +244,7 @@ describe('load correct share page, based on graphql query', () => {
             album: {
               id: '1',
               title: 'album_title',
+              pathForShare: [],
               subAlbums: [],
               thumbnail: {
                 url: 'https://photoview.example.com/album_thumbnail.jpg',

--- a/ui/src/Pages/SharePage/SharePage.tsx
+++ b/ui/src/Pages/SharePage/SharePage.tsx
@@ -112,13 +112,20 @@ const AuthorizedTokenRoute = () => {
   if (loading) return <div>{t('general.loading.default', 'Loading...')}</div>
 
   if (data?.shareToken.album) {
+    const sharedRootAlbumId = data.shareToken.album.id
+
     const SharedSubAlbumPage = () => {
       const { subAlbum } = useParams()
       if (isNil(subAlbum))
         throw new Error('Expected `subAlbum` param to be defined')
 
       return (
-        <AlbumSharePage albumID={subAlbum} token={token} password={password} />
+        <AlbumSharePage
+          albumID={subAlbum}
+          token={token}
+          password={password}
+          sharedRootAlbumId={sharedRootAlbumId}
+        />
       )
     }
 
@@ -129,9 +136,10 @@ const AuthorizedTokenRoute = () => {
           index
           element={
             <AlbumSharePage
-              albumID={data.shareToken.album.id}
+              albumID={sharedRootAlbumId}
               token={token}
               password={password}
+              sharedRootAlbumId={sharedRootAlbumId}
             />
           }
         />

--- a/ui/src/Pages/SharePage/__generated__/SharePageToken.ts
+++ b/ui/src/Pages/SharePage/__generated__/SharePageToken.ts
@@ -122,7 +122,10 @@ export interface SharePageToken_shareToken_media_exif {
    * The name of the lens
    */
   lens: string | null;
-  dateShot: Time | null;
+  /**
+   * The date when the photo is shot
+   */
+  dateShot: string | null;
   /**
    * The exposure time of the image
    */

--- a/ui/src/Pages/SharePage/__generated__/shareAlbumQuery.ts
+++ b/ui/src/Pages/SharePage/__generated__/shareAlbumQuery.ts
@@ -9,6 +9,12 @@ import { OrderDirection, MediaType } from "./../../../__generated__/globalTypes"
 // GraphQL query operation: shareAlbumQuery
 // ====================================================
 
+export interface shareAlbumQuery_album_parentAlbum {
+  __typename: "Album";
+  id: string;
+  title: string;
+}
+
 export interface shareAlbumQuery_album_subAlbums_thumbnail_thumbnail {
   __typename: "MediaURL";
   /**
@@ -136,7 +142,10 @@ export interface shareAlbumQuery_album_media_exif {
    * The name of the lens
    */
   lens: string | null;
-  dateShot: Time | null;
+  /**
+   * The date when the photo is shot
+   */
+  dateShot: string | null;
   /**
    * The exposure time of the image
    */
@@ -199,6 +208,10 @@ export interface shareAlbumQuery_album {
   __typename: "Album";
   id: string;
   title: string;
+  /**
+   * The album which contains this album
+   */
+  parentAlbum: shareAlbumQuery_album_parentAlbum | null;
   /**
    * The albums contained in this album
    */

--- a/ui/src/Pages/SharePage/__generated__/shareAlbumQuery.ts
+++ b/ui/src/Pages/SharePage/__generated__/shareAlbumQuery.ts
@@ -9,7 +9,7 @@ import { OrderDirection, MediaType } from "./../../../__generated__/globalTypes"
 // GraphQL query operation: shareAlbumQuery
 // ====================================================
 
-export interface shareAlbumQuery_album_parentAlbum {
+export interface shareAlbumQuery_album_pathForShare {
   __typename: "Album";
   id: string;
   title: string;
@@ -209,9 +209,9 @@ export interface shareAlbumQuery_album {
   id: string;
   title: string;
   /**
-   * The album which contains this album
+   * Breadcrumb path for shared albums, limited to the share root
    */
-  parentAlbum: shareAlbumQuery_album_parentAlbum | null;
+  pathForShare: shareAlbumQuery_album_pathForShare[];
   /**
    * The albums contained in this album
    */
@@ -234,6 +234,7 @@ export interface shareAlbumQueryVariables {
   id: string;
   token: string;
   password?: string | null;
+  rootAlbumId: string;
   mediaOrderBy?: string | null;
   mediaOrderDirection?: OrderDirection | null;
   limit?: number | null;

--- a/ui/src/components/album/AlbumTitle.tsx
+++ b/ui/src/components/album/AlbumTitle.tsx
@@ -64,14 +64,14 @@ const AlbumTitle = ({ album, disableLink = false, shareBreadcrumbPath, customBre
     if (!album) return
 
     // Only fetch path if authenticated and no share breadcrumb provided
-    if (authToken() && disableLink == true && !shareBreadcrumbPath) {
+    if (authToken() && disableLink === true && !shareBreadcrumbPath) {
       fetchPath({
         variables: {
           id: album.id,
         },
       })
     }
-  }, [album, shareBreadcrumbPath])
+  }, [album, shareBreadcrumbPath, disableLink, fetchPath])
 
   const delay = useDelay(200, [album])
 

--- a/ui/src/components/album/AlbumTitle.tsx
+++ b/ui/src/components/album/AlbumTitle.tsx
@@ -38,15 +38,24 @@ const ALBUM_PATH_QUERY = gql`
   }
 `
 
+type BreadcrumbAlbum = {
+  id: string
+  title: string
+}
+
 type AlbumTitleProps = {
   album?: {
     id: string
     title: string
   }
   disableLink: boolean
+  // Optional breadcrumb path for share pages (avoids needing auth)
+  shareBreadcrumbPath?: BreadcrumbAlbum[]
+  // Custom link builder for share pages
+  customBreadcrumbLink?: (albumId: string) => string
 }
 
-const AlbumTitle = ({ album, disableLink = false }: AlbumTitleProps) => {
+const AlbumTitle = ({ album, disableLink = false, shareBreadcrumbPath, customBreadcrumbLink }: AlbumTitleProps) => {
   const [fetchPath, { data: pathData }] =
     useLazyQuery<albumPathQuery>(ALBUM_PATH_QUERY)
   const { updateSidebar } = useContext(SidebarContext)
@@ -54,14 +63,15 @@ const AlbumTitle = ({ album, disableLink = false }: AlbumTitleProps) => {
   useEffect(() => {
     if (!album) return
 
-    if (authToken() && disableLink == true) {
+    // Only fetch path if authenticated and no share breadcrumb provided
+    if (authToken() && disableLink == true && !shareBreadcrumbPath) {
       fetchPath({
         variables: {
           id: album.id,
         },
       })
     }
-  }, [album])
+  }, [album, shareBreadcrumbPath])
 
   const delay = useDelay(200, [album])
 
@@ -80,16 +90,22 @@ const AlbumTitle = ({ album, disableLink = false }: AlbumTitleProps) => {
 
   let title = <span>{album.title}</span>
 
-  const path = pathData?.album.path || []
+  // Use share breadcrumb path if provided, otherwise use fetched path
+  const path = shareBreadcrumbPath || pathData?.album.path || []
 
   const breadcrumbSections = path
     .slice()
     .reverse()
-    .map(x => (
-      <li key={x.id} className="inline-block hover:underline">
-        <Link to={`/album/${x.id}`}>{x.title}</Link>
-      </li>
-    ))
+    .map(x => {
+      const link = customBreadcrumbLink
+        ? customBreadcrumbLink(x.id)
+        : `/album/${x.id}`
+      return (
+        <li key={x.id} className="inline-block hover:underline">
+          <Link to={link}>{x.title}</Link>
+        </li>
+      )
+    })
 
   if (!disableLink) {
     title = <Link to={`/album/${album.id}`}>{title}</Link>

--- a/ui/src/components/albumGallery/AlbumGallery.tsx
+++ b/ui/src/components/albumGallery/AlbumGallery.tsx
@@ -39,6 +39,11 @@ export const ALBUM_GALLERY_FRAGMENT = gql`
   }
 `
 
+type BreadcrumbAlbum = {
+  id: string
+  title: string
+}
+
 type AlbumGalleryProps = {
   album?: AlbumGalleryFields
   loading?: boolean
@@ -49,6 +54,8 @@ type AlbumGalleryProps = {
   ordering?: MediaOrdering
   onlyFavorites?: boolean
   onFavorite?(): void
+  // Optional breadcrumb path for share pages
+  shareBreadcrumbPath?: BreadcrumbAlbum[]
 }
 
 const AlbumGallery = React.forwardRef(
@@ -62,6 +69,7 @@ const AlbumGallery = React.forwardRef(
       setOrdering,
       ordering,
       onlyFavorites = false,
+      shareBreadcrumbPath,
     }: AlbumGalleryProps,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
@@ -109,7 +117,12 @@ const AlbumGallery = React.forwardRef(
             ordering={ordering}
           />
         )}
-        <AlbumTitle album={album} disableLink />
+        <AlbumTitle
+          album={album}
+          disableLink
+          shareBreadcrumbPath={shareBreadcrumbPath}
+          customBreadcrumbLink={customAlbumLink}
+        />
         {subAlbumElement}
         <MediaGallery
           loading={loading}

--- a/ui/src/components/sidebar/MediaSidebar/__generated__/sidebarMediaQuery.ts
+++ b/ui/src/components/sidebar/MediaSidebar/__generated__/sidebarMediaQuery.ts
@@ -101,7 +101,10 @@ export interface sidebarMediaQuery_media_exif {
    * The name of the lens
    */
   lens: string | null;
-  dateShot: Time | null;
+  /**
+   * The date when the photo is shot
+   */
+  dateShot: string | null;
   /**
    * The exposure time of the image
    */


### PR DESCRIPTION
  When sharing an album with subalbums, users can now navigate back
  to parent albums using breadcrumb navigation that matches the
  logged-in user experience.

  Backend changes:
  - Preload ParentAlbum association when querying albums with token credentials
  - Added preloading for both root shared album and subalbum queries

  Frontend changes:
  - Modified SHARE_ALBUM_QUERY to include parentAlbum data
  - Reused BreadcrumbList component from AlbumTitle for consistent styling
  - Added sharedRootAlbumId prop to prevent navigation above shared root
  - Breadcrumb only shows when in a subalbum (not at shared root level)
  - Regenerated TypeScript types from GraphQL schema

The current UI when you are in a shared sub-album:
<img width="526" height="310" alt="image" src="https://github.com/user-attachments/assets/43a7b8bd-5c39-4c5f-bae2-ee69daeefc10" />



The UI after the feature has been implemented:
<img width="470" height="346" alt="image" src="https://github.com/user-attachments/assets/24720243-cfda-428d-8bc7-5b86b03c462f" />



The related feature request is #1366 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared album pages now include a breadcrumb path limited to the shared root, letting users navigate parent albums within a share using the share token and selected root.
  * Breadcrumb data is threaded through gallery and title components and supports custom link generation for breadcrumb items; shared breadcrumbs override local fetching when provided.

* **Tests**
  * Test coverage updated to include shared-root breadcrumb behavior and query variables for shared albums.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->