### PR TITLE
Set access token server side

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Kagami/go-face v0.0.0-20210630145111-0c14797b4d0e
 	github.com/barasher/go-exiftool v1.10.0
 	github.com/buckket/go-blurhash v1.1.0
+	github.com/felixge/httpsnoop v1.0.4
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/google/go-cmp v0.7.0
 	github.com/gorilla/handlers v1.5.2
@@ -33,7 +34,6 @@ require (
 	filippo.io/edwards25519 v1.1.1 // indirect
 	github.com/agnivade/levenshtein v1.2.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/api/graphql/auth/auth.go
+++ b/api/graphql/auth/auth.go
@@ -91,6 +91,7 @@ func UserFromContext(ctx context.Context) *models.User {
 	return raw
 }
 
+// Find the auth-token from the context. REQUIRES AuthCookieSetter to have run.
 func ResolverCookieFromContext(ctx context.Context) *string {
 	raw, _ := ctx.Value(userAccessTokenCtxKey).(*string)
 	return raw

--- a/api/graphql/auth/auth.go
+++ b/api/graphql/auth/auth.go
@@ -93,8 +93,12 @@ func UserFromContext(ctx context.Context) *models.User {
 
 // Find the auth-token from the context. REQUIRES AuthCookieSetter to have run.
 func ResolverCookieFromContext(ctx context.Context) *string {
-	raw, _ := ctx.Value(userAccessTokenCtxKey).(*string)
-	return raw
+	v := ctx.Value(userAccessTokenCtxKey)
+	if v == nil {
+		return nil
+	}
+
+	return v.(*string)
 }
 
 func AuthWebsocketInit() func(context.Context, transport.InitPayload) (context.Context, *transport.InitPayload, error) {

--- a/api/graphql/auth/auth.go
+++ b/api/graphql/auth/auth.go
@@ -19,9 +19,11 @@ var bearerRegex = regexp.MustCompile("^(?i)Bearer ([a-zA-Z0-9]{24})$")
 const INVALID_AUTH_TOKEN = "invalid authorization token"
 const INTERNAL_SERVER_ERROR = "internal server error"
 
-// A private key for context that only this package can access. This is important
+// Private keys for context that only this package can access. This is important
 // to prevent collisions between different context uses
 var userCtxKey = &contextKey{"user"}
+
+var userAccessTokenCtxKey = &contextKey{"userAccessToken"}
 
 type contextKey struct {
 	name string
@@ -86,6 +88,11 @@ func TokenFromBearer(bearer *string) (*string, error) {
 // UserFromContext finds the user from the context. REQUIRES Middleware to have run.
 func UserFromContext(ctx context.Context) *models.User {
 	raw, _ := ctx.Value(userCtxKey).(*models.User)
+	return raw
+}
+
+func ResolverCookieFromContext(ctx context.Context) *string {
+	raw, _ := ctx.Value(userAccessTokenCtxKey).(*string)
 	return raw
 }
 

--- a/api/graphql/auth/auth_cookie_setter.go
+++ b/api/graphql/auth/auth_cookie_setter.go
@@ -1,0 +1,42 @@
+package auth
+
+import (
+	context "context"
+	http "net/http"
+)
+
+type authResponseWriter struct {
+	http.ResponseWriter
+	http.Hijacker
+	userIDToResolver string
+	userIDFromCookie string
+}
+
+func (w *authResponseWriter) Write(b []byte) (int, error) {
+	if w.userIDToResolver != w.userIDFromCookie {
+		http.SetCookie(w, &http.Cookie{
+			Name:     "auth-token",
+			Value:    w.userIDToResolver,
+			Path:     "/",
+			SameSite: http.SameSiteLaxMode,
+		})
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+func AuthCookieSetter(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		arw := authResponseWriter{w, w.(http.Hijacker), "", ""}
+		userIDContextKey := userAccessTokenCtxKey
+
+		c, _ := r.Cookie("auth-token")
+		if c != nil {
+			arw.userIDFromCookie = c.Value
+			arw.userIDToResolver = c.Value
+		}
+		ctx := context.WithValue(r.Context(), userIDContextKey, &arw.userIDToResolver)
+		r = r.WithContext(ctx)
+
+		next.ServeHTTP(&arw, r)
+	})
+}

--- a/api/graphql/auth/auth_cookie_setter.go
+++ b/api/graphql/auth/auth_cookie_setter.go
@@ -4,58 +4,9 @@ import (
 	context "context"
 	http "net/http"
 	"time"
+
+	"github.com/felixge/httpsnoop"
 )
-
-// authResponseWriter wraps http.ResponseWriter to intercept response writes and
-// inject an auth-token cookie when a token has been set by a GraphQL resolver.
-// It also embeds http.Hijacker to support WebSocket upgrades.
-type authResponseWriter struct {
-	http.ResponseWriter
-	http.Hijacker
-	authTokenFromResolver string
-	separateDomain        bool
-	cookieWritten         bool
-}
-
-// writeAuthCookieIfNeeded sets the auth-token cookie on the response if a token
-// was provided by a resolver and the cookie has not already been written.
-// For cross-origin deployments (separateDomain=true), it uses SameSite=None;Secure.
-func (w *authResponseWriter) writeAuthCookieIfNeeded() {
-	if w.cookieWritten || w.authTokenFromResolver == "" {
-		return
-	}
-
-	sameSite := http.SameSiteLaxMode
-	secure := false
-	if w.separateDomain {
-		// SameSite=None;Secure is required for cross-origin cookies (e.g. UI and API on different domains)
-		sameSite = http.SameSiteNoneMode
-		secure = true
-	}
-	http.SetCookie(w, &http.Cookie{
-		Name:     "auth-token",
-		Value:    w.authTokenFromResolver,
-		Path:     "/",
-		SameSite: sameSite,
-		Secure:   secure,
-		Expires:  time.Now().Add(14 * 24 * time.Hour),
-	})
-	w.cookieWritten = true
-}
-
-// WriteHeader intercepts the status code write to ensure the auth cookie is set
-// before headers are flushed to the client.
-func (w *authResponseWriter) WriteHeader(statusCode int) {
-	w.writeAuthCookieIfNeeded()
-	w.ResponseWriter.WriteHeader(statusCode)
-}
-
-// Write intercepts the response body write to ensure the auth cookie is set
-// before any body bytes are sent, in case WriteHeader was not called explicitly.
-func (w *authResponseWriter) Write(b []byte) (int, error) {
-	w.writeAuthCookieIfNeeded()
-	return w.ResponseWriter.Write(b)
-}
 
 // AuthCookieSetter returns HTTP middleware that automatically sets an auth-token
 // cookie on responses when a GraphQL resolver has produced an access token.
@@ -66,13 +17,48 @@ func (w *authResponseWriter) Write(b []byte) (int, error) {
 func AuthCookieSetter(separateDomain bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			arw := authResponseWriter{w, w.(http.Hijacker), "", separateDomain, false}
-			userIDContextKey := userAccessTokenCtxKey
+			var authToken string
+			cookieWritten := false
 
-			ctx := context.WithValue(r.Context(), userIDContextKey, &arw.authTokenFromResolver)
-			r = r.WithContext(ctx)
+			writeIfNeeded := func() {
+				if cookieWritten || authToken == "" {
+					return
+				}
+				sameSite := http.SameSiteLaxMode
+				secure := false
+				if separateDomain {
+					// SameSite=None;Secure is required for cross-origin cookies (e.g. UI and API on different domains)
+					sameSite = http.SameSiteNoneMode
+					secure = true
+				}
+				http.SetCookie(w, &http.Cookie{
+					Name:     "auth-token",
+					Value:    authToken,
+					Path:     "/",
+					SameSite: sameSite,
+					Secure:   secure,
+					Expires:  time.Now().Add(14 * 24 * time.Hour),
+				})
+				cookieWritten = true
+			}
 
-			next.ServeHTTP(&arw, r)
+			wrapped := httpsnoop.Wrap(w, httpsnoop.Hooks{
+				WriteHeader: func(next httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+					return func(code int) {
+						writeIfNeeded()
+						next(code)
+					}
+				},
+				Write: func(next httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+					return func(b []byte) (int, error) {
+						writeIfNeeded()
+						return next(b)
+					}
+				},
+			})
+
+			ctx := context.WithValue(r.Context(), userAccessTokenCtxKey, &authToken)
+			next.ServeHTTP(wrapped, r.WithContext(ctx))
 		})
 	}
 }

--- a/api/graphql/auth/auth_cookie_setter.go
+++ b/api/graphql/auth/auth_cookie_setter.go
@@ -21,24 +21,26 @@ type authResponseWriter struct {
 // was provided by a resolver and the cookie has not already been written.
 // For cross-origin deployments (separateDomain=true), it uses SameSite=None;Secure.
 func (w *authResponseWriter) writeAuthCookieIfNeeded() {
-	if w.cookieWritten == false && w.authTokenFromResolver != "" {
-		sameSite := http.SameSiteLaxMode
-		secure := false
-		if w.separateDomain {
-			// SameSite=None;Secure is required for cross-origin cookies (e.g. UI and API on different domains)
-			sameSite = http.SameSiteNoneMode
-			secure = true
-		}
-		http.SetCookie(w, &http.Cookie{
-			Name:     "auth-token",
-			Value:    w.authTokenFromResolver,
-			Path:     "/",
-			SameSite: sameSite,
-			Secure:   secure,
-			Expires:  time.Now().Add(14 * 24 * time.Hour),
-		})
-		w.cookieWritten = true
+	if w.cookieWritten || w.authTokenFromResolver == "" {
+		return
 	}
+
+	sameSite := http.SameSiteLaxMode
+	secure := false
+	if w.separateDomain {
+		// SameSite=None;Secure is required for cross-origin cookies (e.g. UI and API on different domains)
+		sameSite = http.SameSiteNoneMode
+		secure = true
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     "auth-token",
+		Value:    w.authTokenFromResolver,
+		Path:     "/",
+		SameSite: sameSite,
+		Secure:   secure,
+		Expires:  time.Now().Add(14 * 24 * time.Hour),
+	})
+	w.cookieWritten = true
 }
 
 // WriteHeader intercepts the status code write to ensure the auth cookie is set

--- a/api/graphql/auth/auth_cookie_setter.go
+++ b/api/graphql/auth/auth_cookie_setter.go
@@ -3,22 +3,23 @@ package auth
 import (
 	context "context"
 	http "net/http"
+	"time"
 )
 
 type authResponseWriter struct {
 	http.ResponseWriter
 	http.Hijacker
-	userIDToResolver string
-	userIDFromCookie string
+	authTokenFromResolver string
 }
 
 func (w *authResponseWriter) Write(b []byte) (int, error) {
-	if w.userIDToResolver != w.userIDFromCookie {
+	if w.authTokenFromResolver != "" {
 		http.SetCookie(w, &http.Cookie{
 			Name:     "auth-token",
-			Value:    w.userIDToResolver,
+			Value:    w.authTokenFromResolver,
 			Path:     "/",
 			SameSite: http.SameSiteLaxMode,
+			Expires:  time.Now().Add(14 * 24 * time.Hour),
 		})
 	}
 	return w.ResponseWriter.Write(b)
@@ -26,15 +27,10 @@ func (w *authResponseWriter) Write(b []byte) (int, error) {
 
 func AuthCookieSetter(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		arw := authResponseWriter{w, w.(http.Hijacker), "", ""}
+		arw := authResponseWriter{w, w.(http.Hijacker), ""}
 		userIDContextKey := userAccessTokenCtxKey
 
-		c, _ := r.Cookie("auth-token")
-		if c != nil {
-			arw.userIDFromCookie = c.Value
-			arw.userIDToResolver = c.Value
-		}
-		ctx := context.WithValue(r.Context(), userIDContextKey, &arw.userIDToResolver)
+		ctx := context.WithValue(r.Context(), userIDContextKey, &arw.authTokenFromResolver)
 		r = r.WithContext(ctx)
 
 		next.ServeHTTP(&arw, r)

--- a/api/graphql/auth/auth_cookie_setter.go
+++ b/api/graphql/auth/auth_cookie_setter.go
@@ -6,6 +6,9 @@ import (
 	"time"
 )
 
+// authResponseWriter wraps http.ResponseWriter to intercept response writes and
+// inject an auth-token cookie when a token has been set by a GraphQL resolver.
+// It also embeds http.Hijacker to support WebSocket upgrades.
 type authResponseWriter struct {
 	http.ResponseWriter
 	http.Hijacker
@@ -14,6 +17,9 @@ type authResponseWriter struct {
 	cookieWritten         bool
 }
 
+// writeAuthCookieIfNeeded sets the auth-token cookie on the response if a token
+// was provided by a resolver and the cookie has not already been written.
+// For cross-origin deployments (separateDomain=true), it uses SameSite=None;Secure.
 func (w *authResponseWriter) writeAuthCookieIfNeeded() {
 	if w.cookieWritten == false && w.authTokenFromResolver != "" {
 		sameSite := http.SameSiteLaxMode
@@ -35,16 +41,26 @@ func (w *authResponseWriter) writeAuthCookieIfNeeded() {
 	}
 }
 
+// WriteHeader intercepts the status code write to ensure the auth cookie is set
+// before headers are flushed to the client.
 func (w *authResponseWriter) WriteHeader(statusCode int) {
 	w.writeAuthCookieIfNeeded()
 	w.ResponseWriter.WriteHeader(statusCode)
 }
 
+// Write intercepts the response body write to ensure the auth cookie is set
+// before any body bytes are sent, in case WriteHeader was not called explicitly.
 func (w *authResponseWriter) Write(b []byte) (int, error) {
 	w.writeAuthCookieIfNeeded()
 	return w.ResponseWriter.Write(b)
 }
 
+// AuthCookieSetter returns HTTP middleware that automatically sets an auth-token
+// cookie on responses when a GraphQL resolver has produced an access token.
+// It stores a pointer to the token field in the request context under
+// userAccessTokenCtxKey so resolvers can populate it directly.
+// separateDomain should be true when the UI and API are served from different
+// origins, which requires SameSite=None;Secure cookie attributes.
 func AuthCookieSetter(separateDomain bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/api/graphql/auth/auth_cookie_setter.go
+++ b/api/graphql/auth/auth_cookie_setter.go
@@ -10,29 +10,40 @@ type authResponseWriter struct {
 	http.ResponseWriter
 	http.Hijacker
 	authTokenFromResolver string
+	separateDomain        bool
 }
 
 func (w *authResponseWriter) Write(b []byte) (int, error) {
 	if w.authTokenFromResolver != "" {
+		sameSite := http.SameSiteLaxMode
+		secure := false
+		if w.separateDomain {
+			// SameSite=None;Secure is required for cross-origin cookies (e.g. UI and API on different domains)
+			sameSite = http.SameSiteNoneMode
+			secure = true
+		}
 		http.SetCookie(w, &http.Cookie{
 			Name:     "auth-token",
 			Value:    w.authTokenFromResolver,
 			Path:     "/",
-			SameSite: http.SameSiteLaxMode,
+			SameSite: sameSite,
+			Secure:   secure,
 			Expires:  time.Now().Add(14 * 24 * time.Hour),
 		})
 	}
 	return w.ResponseWriter.Write(b)
 }
 
-func AuthCookieSetter(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		arw := authResponseWriter{w, w.(http.Hijacker), ""}
-		userIDContextKey := userAccessTokenCtxKey
+func AuthCookieSetter(separateDomain bool) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			arw := authResponseWriter{w, w.(http.Hijacker), "", separateDomain}
+			userIDContextKey := userAccessTokenCtxKey
 
-		ctx := context.WithValue(r.Context(), userIDContextKey, &arw.authTokenFromResolver)
-		r = r.WithContext(ctx)
+			ctx := context.WithValue(r.Context(), userIDContextKey, &arw.authTokenFromResolver)
+			r = r.WithContext(ctx)
 
-		next.ServeHTTP(&arw, r)
-	})
+			next.ServeHTTP(&arw, r)
+		})
+	}
 }

--- a/api/graphql/auth/auth_cookie_setter.go
+++ b/api/graphql/auth/auth_cookie_setter.go
@@ -11,10 +11,11 @@ type authResponseWriter struct {
 	http.Hijacker
 	authTokenFromResolver string
 	separateDomain        bool
+	cookieWritten         bool
 }
 
-func (w *authResponseWriter) WriteHeader(statusCode int) {
-	if w.authTokenFromResolver != "" {
+func (w *authResponseWriter) writeAuthCookieIfNeeded() {
+	if w.cookieWritten == false && w.authTokenFromResolver != "" {
 		sameSite := http.SameSiteLaxMode
 		secure := false
 		if w.separateDomain {
@@ -30,14 +31,24 @@ func (w *authResponseWriter) WriteHeader(statusCode int) {
 			Secure:   secure,
 			Expires:  time.Now().Add(14 * 24 * time.Hour),
 		})
+		w.cookieWritten = true
 	}
+}
+
+func (w *authResponseWriter) WriteHeader(statusCode int) {
+	w.writeAuthCookieIfNeeded()
 	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *authResponseWriter) Write(b []byte) (int, error) {
+	w.writeAuthCookieIfNeeded()
+	return w.ResponseWriter.Write(b)
 }
 
 func AuthCookieSetter(separateDomain bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			arw := authResponseWriter{w, w.(http.Hijacker), "", separateDomain}
+			arw := authResponseWriter{w, w.(http.Hijacker), "", separateDomain, false}
 			userIDContextKey := userAccessTokenCtxKey
 
 			ctx := context.WithValue(r.Context(), userIDContextKey, &arw.authTokenFromResolver)

--- a/api/graphql/auth/auth_cookie_setter.go
+++ b/api/graphql/auth/auth_cookie_setter.go
@@ -13,7 +13,7 @@ type authResponseWriter struct {
 	separateDomain        bool
 }
 
-func (w *authResponseWriter) Write(b []byte) (int, error) {
+func (w *authResponseWriter) WriteHeader(statusCode int) {
 	if w.authTokenFromResolver != "" {
 		sameSite := http.SameSiteLaxMode
 		secure := false
@@ -31,7 +31,7 @@ func (w *authResponseWriter) Write(b []byte) (int, error) {
 			Expires:  time.Now().Add(14 * 24 * time.Hour),
 		})
 	}
-	return w.ResponseWriter.Write(b)
+	w.ResponseWriter.WriteHeader(statusCode)
 }
 
 func AuthCookieSetter(separateDomain bool) func(http.Handler) http.Handler {

--- a/api/graphql/auth/auth_cookie_setter_test.go
+++ b/api/graphql/auth/auth_cookie_setter_test.go
@@ -24,14 +24,14 @@ func setResponseAuthCookieHandler(token string) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cookie := auth.ResolverCookieFromContext(r.Context())
 		*cookie = token
-		w.Write([]byte("ok"))
+		w.WriteHeader(200)
 	})
 }
 
 // Emulate an endpoint that is not AuthorizeUser or InitialSetupWizard
 func noResponseAuthCookieHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("ok"))
+		w.WriteHeader(200)
 	})
 }
 

--- a/api/graphql/auth/auth_cookie_setter_test.go
+++ b/api/graphql/auth/auth_cookie_setter_test.go
@@ -40,10 +40,17 @@ func TestAuthCookieSetterMiddleware(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		responseAuthCookieVal string
+		uiOnSeparateDomain    bool
 	}{
 		{
-			name:                  "Login or initial setup endpoint sets auth cookie",
+			name:                  "Login or initial setup endpoint sets auth cookie with samesite lax",
 			responseAuthCookieVal: "cookie",
+			uiOnSeparateDomain:    false,
+		},
+		{
+			name:                  "Login or initial setup endpoint sets auth cookie with samesite none",
+			responseAuthCookieVal: "cookie",
+			uiOnSeparateDomain:    true,
 		},
 		{
 			name:                  "Non Login or initial setup endpoint does not set auth cookie",
@@ -58,23 +65,34 @@ func TestAuthCookieSetterMiddleware(t *testing.T) {
 			var authHandler http.Handler
 
 			if tc.responseAuthCookieVal != "" {
-				authHandler = auth.AuthCookieSetter(setResponseAuthCookieHandler(tc.responseAuthCookieVal))
+				authHandler = auth.AuthCookieSetter(tc.uiOnSeparateDomain)(setResponseAuthCookieHandler(tc.responseAuthCookieVal))
 			} else {
-				authHandler = auth.AuthCookieSetter(noResponseAuthCookieHandler())
+				authHandler = auth.AuthCookieSetter(tc.uiOnSeparateDomain)(noResponseAuthCookieHandler())
 			}
 
 			recorder := &hijackableRecorder{httptest.NewRecorder()}
 			authHandler.ServeHTTP(recorder, req)
 
-			var authTokenValue string
+			var authToken *http.Cookie
 			for _, cookie := range recorder.Result().Cookies() {
 				if cookie.Name == "auth-token" {
-					authTokenValue = cookie.Value
+					authToken = cookie
 					break
 				}
 			}
 
-			assert.Equal(t, tc.responseAuthCookieVal, authTokenValue)
+			if tc.responseAuthCookieVal != "" {
+				assert.Equal(t, tc.responseAuthCookieVal, authToken.Value)
+				if tc.uiOnSeparateDomain {
+					assert.Equal(t, http.SameSiteNoneMode, authToken.SameSite)
+					assert.True(t, authToken.Secure)
+				} else {
+					assert.Equal(t, http.SameSiteLaxMode, authToken.SameSite)
+					assert.False(t, authToken.Secure)
+				}
+			} else {
+				assert.Nil(t, authToken)
+			}
 		})
 	}
 }

--- a/api/graphql/auth/auth_cookie_setter_test.go
+++ b/api/graphql/auth/auth_cookie_setter_test.go
@@ -1,0 +1,80 @@
+package auth_test
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/photoview/photoview/api/graphql/auth"
+	"github.com/stretchr/testify/assert"
+)
+
+type hijackableRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (h *hijackableRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return nil, nil, nil
+}
+
+// Emulate what the AuthorizeUser and InitialSetupWizard resolvers do without depending on them directly
+func setResponseAuthCookieHandler(token string) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie := auth.ResolverCookieFromContext(r.Context())
+		*cookie = token
+		w.Write([]byte("ok"))
+	})
+}
+
+// Emulate an endpoint that is not AuthorizeUser or InitialSetupWizard
+func noResponseAuthCookieHandler() http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("ok"))
+	})
+}
+
+func TestAuthCookieSetterMiddleware(t *testing.T) {
+
+	testCases := []struct {
+		name                  string
+		responseAuthCookieVal string
+	}{
+		{
+			name:                  "Login or initial setup endpoint sets auth cookie",
+			responseAuthCookieVal: "cookie",
+		},
+		{
+			name:                  "Non Login or initial setup endpoint does not set auth cookie",
+			responseAuthCookieVal: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/graphql", nil)
+
+			var authHandler http.Handler
+
+			if tc.responseAuthCookieVal != "" {
+				authHandler = auth.AuthCookieSetter(setResponseAuthCookieHandler(tc.responseAuthCookieVal))
+			} else {
+				authHandler = auth.AuthCookieSetter(noResponseAuthCookieHandler())
+			}
+
+			recorder := &hijackableRecorder{httptest.NewRecorder()}
+			authHandler.ServeHTTP(recorder, req)
+
+			var authTokenValue string
+			for _, cookie := range recorder.Result().Cookies() {
+				if cookie.Name == "auth-token" {
+					authTokenValue = cookie.Value
+					break
+				}
+			}
+
+			assert.Equal(t, tc.responseAuthCookieVal, authTokenValue)
+		})
+	}
+}

--- a/api/graphql/auth/auth_cookie_setter_test.go
+++ b/api/graphql/auth/auth_cookie_setter_test.go
@@ -11,10 +11,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// hijackableRecorder wraps httptest.ResponseRecorder with a no-op Hijack method
+// so it satisfies the http.Hijacker interface required by authResponseWriter.
 type hijackableRecorder struct {
 	*httptest.ResponseRecorder
 }
 
+// Hijack implements http.Hijacker as a no-op for testing purposes.
 func (h *hijackableRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return nil, nil, nil
 }
@@ -35,6 +38,9 @@ func noResponseAuthCookieHandler() http.HandlerFunc {
 	})
 }
 
+// TestAuthCookieSetterMiddleware verifies that AuthCookieSetter middleware sets
+// the auth-token cookie with the correct value and SameSite/Secure attributes
+// when a resolver writes a token, and omits the cookie when no token is set.
 func TestAuthCookieSetterMiddleware(t *testing.T) {
 
 	testCases := []struct {

--- a/api/graphql/auth/auth_cookie_setter_test.go
+++ b/api/graphql/auth/auth_cookie_setter_test.go
@@ -1,8 +1,6 @@
 package auth_test
 
 import (
-	"bufio"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -10,17 +8,6 @@ import (
 	"github.com/photoview/photoview/api/graphql/auth"
 	"github.com/stretchr/testify/assert"
 )
-
-// hijackableRecorder wraps httptest.ResponseRecorder with a no-op Hijack method
-// so it satisfies the http.Hijacker interface required by authResponseWriter.
-type hijackableRecorder struct {
-	*httptest.ResponseRecorder
-}
-
-// Hijack implements http.Hijacker as a no-op for testing purposes.
-func (h *hijackableRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	return nil, nil, nil
-}
 
 // Emulate what the AuthorizeUser and InitialSetupWizard resolvers do without depending on them directly
 func setResponseAuthCookieHandler(token string) http.HandlerFunc {
@@ -102,7 +89,7 @@ func TestAuthCookieSetterMiddleware(t *testing.T) {
 				authHandler = auth.AuthCookieSetter(tc.uiOnSeparateDomain)(noResponseAuthCookieHandler())
 			}
 
-			recorder := &hijackableRecorder{httptest.NewRecorder()}
+			recorder := httptest.NewRecorder()
 			authHandler.ServeHTTP(recorder, req)
 
 			var authToken *http.Cookie

--- a/api/graphql/auth/auth_cookie_setter_test.go
+++ b/api/graphql/auth/auth_cookie_setter_test.go
@@ -31,6 +31,16 @@ func setResponseAuthCookieHandler(token string) http.HandlerFunc {
 	})
 }
 
+// setResponseAuthCookieHandlerViaWrite is like setResponseAuthCookieHandler but
+// triggers the cookie via Write instead of WriteHeader, exercising the Write intercept path.
+func setResponseAuthCookieHandlerViaWrite(token string) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cookie := auth.ResolverCookieFromContext(r.Context())
+		*cookie = token
+		w.Write([]byte("ok"))
+	})
+}
+
 // Emulate an endpoint that is not AuthorizeUser or InitialSetupWizard
 func noResponseAuthCookieHandler() http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -47,6 +57,7 @@ func TestAuthCookieSetterMiddleware(t *testing.T) {
 		name                  string
 		responseAuthCookieVal string
 		uiOnSeparateDomain    bool
+		useWrite              bool
 	}{
 		{
 			name:                  "Login or initial setup endpoint sets auth cookie with samesite lax",
@@ -62,6 +73,18 @@ func TestAuthCookieSetterMiddleware(t *testing.T) {
 			name:                  "Non Login or initial setup endpoint does not set auth cookie",
 			responseAuthCookieVal: "",
 		},
+		{
+			name:                  "Auth cookie set via Write with samesite lax",
+			responseAuthCookieVal: "cookie",
+			uiOnSeparateDomain:    false,
+			useWrite:              true,
+		},
+		{
+			name:                  "Auth cookie set via Write with samesite none on separate domain",
+			responseAuthCookieVal: "cookie",
+			uiOnSeparateDomain:    true,
+			useWrite:              true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -70,9 +93,12 @@ func TestAuthCookieSetterMiddleware(t *testing.T) {
 
 			var authHandler http.Handler
 
-			if tc.responseAuthCookieVal != "" {
+			switch {
+			case tc.responseAuthCookieVal != "" && tc.useWrite:
+				authHandler = auth.AuthCookieSetter(tc.uiOnSeparateDomain)(setResponseAuthCookieHandlerViaWrite(tc.responseAuthCookieVal))
+			case tc.responseAuthCookieVal != "":
 				authHandler = auth.AuthCookieSetter(tc.uiOnSeparateDomain)(setResponseAuthCookieHandler(tc.responseAuthCookieVal))
-			} else {
+			default:
 				authHandler = auth.AuthCookieSetter(tc.uiOnSeparateDomain)(noResponseAuthCookieHandler())
 			}
 

--- a/api/graphql/resolvers/user.go
+++ b/api/graphql/resolvers/user.go
@@ -46,6 +46,10 @@ func (r *mutationResolver) AuthorizeUser(ctx context.Context, username string, p
 		return nil, transactionError
 	}
 
+	// This sets a value that Write will pick up later and set in response Set-Cookie headers
+	cookie := auth.ResolverCookieFromContext(ctx)
+	*cookie = token.Value
+
 	return &models.AuthorizeResult{
 		Success: true,
 		Status:  "ok",
@@ -98,6 +102,10 @@ func (r *mutationResolver) InitialSetupWizard(ctx context.Context, username stri
 			Status:  err.Error(),
 		}, nil
 	}
+
+	// This sets a value that Write will pick up later and set in response Set-Cookie headers
+	cookie := auth.ResolverCookieFromContext(ctx)
+	*cookie = token.Value
 
 	return &models.AuthorizeResult{
 		Success: true,

--- a/api/server.go
+++ b/api/server.go
@@ -75,7 +75,7 @@ func main() {
 	rootRouter.Use(dataloader.Middleware(db))
 	rootRouter.Use(auth.Middleware(db))
 	rootRouter.Use(server.LoggingMiddleware)
-	rootRouter.Use(auth.AuthCookieSetter)
+	rootRouter.Use(auth.AuthCookieSetter(utils.EnvUIEndpoint.GetValue() != ""))
 	rootRouter.Use(server.CORSMiddleware(devMode))
 
 	apiListenURL := utils.ApiListenUrl()

--- a/api/server.go
+++ b/api/server.go
@@ -75,6 +75,7 @@ func main() {
 	rootRouter.Use(dataloader.Middleware(db))
 	rootRouter.Use(auth.Middleware(db))
 	rootRouter.Use(server.LoggingMiddleware)
+	rootRouter.Use(auth.AuthCookieSetter)
 	rootRouter.Use(server.CORSMiddleware(devMode))
 
 	apiListenURL := utils.ApiListenUrl()

--- a/ui/src/Pages/LoginPage/InitialSetupPage.tsx
+++ b/ui/src/Pages/LoginPage/InitialSetupPage.tsx
@@ -67,8 +67,8 @@ const InitialSetupPage = () => {
       onCompleted: data => {
         if (!data.initialSetupWizard) return
 
-        const { success, token } = data.initialSetupWizard
-        if (success && token) login(token)
+        const { success } = data.initialSetupWizard
+        if (success) login()
       },
     })
 

--- a/ui/src/Pages/LoginPage/LoginPage.tsx
+++ b/ui/src/Pages/LoginPage/LoginPage.tsx
@@ -52,10 +52,10 @@ const LoginForm = () => {
     AuthorizeVariables
   >(authorizeMutation, {
     onCompleted: data => {
-      const { success, token } = data.authorizeUser
+      const { success } = data.authorizeUser
 
-      if (success && token) {
-        login(token)
+      if (success) {
+        login()
       }
     },
   })

--- a/ui/src/Pages/LoginPage/loginUtilities.tsx
+++ b/ui/src/Pages/LoginPage/loginUtilities.tsx
@@ -10,8 +10,7 @@ export const INITIAL_SETUP_QUERY = gql`
   }
 `
 
-export function login(token: string) {
-  saveTokenCookie(token)
+export function login() {
   window.location.href = `${import.meta.env.BASE_URL}`
 }
 

--- a/ui/src/components/sidebar/__generated__/sidebarSetExpireShare.ts
+++ b/ui/src/components/sidebar/__generated__/sidebarSetExpireShare.ts
@@ -1,0 +1,25 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: sidebarSetExpireShare
+// ====================================================
+
+export interface sidebarSetExpireShare_setExpireShareToken {
+  __typename: "ShareToken";
+  token: string;
+}
+
+export interface sidebarSetExpireShare {
+  /**
+   * Set a Expiration Time for a token
+   */
+  setExpireShareToken: sidebarSetExpireShare_setExpireShareToken;
+}
+
+export interface sidebarSetExpireShareVariables {
+  token: string;
+  expire?: Time | null;
+}


### PR DESCRIPTION
Fix for: https://github.com/photoview/photoview/issues/184

Auth should now work even if the ui and api are hosted on separate domains.

Further improvement would be to not return the auth token in the graphql response, and also set the cookie to HttpOnly to avoid XSS access to the token. I figured that is out of scope for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server now emits an auth cookie to manage sessions automatically.

* **Changes**
  * Client login flow simplified: login no longer requires or passes tokens and runs on success only.
  * Middleware added to surface session tokens produced during requests as Set-Cookie responses.

* **Tests**
  * Added tests validating the cookie-setting middleware behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->