### PR TITLE
Cross build darktable.

### DIFF
--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -1,5 +1,6 @@
 FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:trixie-slim AS base-cross-prep
 ARG TARGETPLATFORM
+ENV BUILD_CACHE_DIR=/build-cache
 SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
 COPY --chmod=0755 prepare.sh /tmp/
 RUN /tmp/prepare.sh \
@@ -8,7 +9,6 @@ RUN /tmp/prepare.sh \
 FROM base-cross-prep AS build-libheif
 ARG LIBHEIF_VERSION
 ARG TARGETARCH
-ENV BUILD_CACHE_DIR=/build-cache
 WORKDIR /tmp/build-libheif
 COPY --chmod=0755 build_libheif.sh .
 RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=libheif-${TARGETARCH}-${LIBHEIF_VERSION} \
@@ -19,10 +19,22 @@ RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=libheif-${TARGETARCH}-${LIBH
     && set -a && source /env && set +a \
     && ./build_libheif.sh
 
+FROM build-libheif AS build-darktable
+ARG DARKTABLE_VERSION
+ARG TARGETARCH
+WORKDIR /tmp/build-darktable
+COPY --chmod=0755 build_darktable.sh .
+RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=darktable-${TARGETARCH}-${DARKTABLE_VERSION} \
+    --mount=type=secret,id=github_token \
+    if [ -f /run/secrets/github_token ]; then \
+    export GITHUB_TOKEN=$(cat /run/secrets/github_token); \
+    fi \
+    && set -a && source /env && set +a \
+    && ./build_darktable.sh
+
 FROM build-libheif AS build-libraw
 ARG LIBRAW_VERSION
 ARG TARGETARCH
-ENV BUILD_CACHE_DIR=/build-cache
 WORKDIR /tmp/build-libraw
 COPY --chmod=0755 build_libraw.sh .
 RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=libraw-${TARGETARCH}-${LIBRAW_VERSION} \
@@ -36,7 +48,6 @@ RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=libraw-${TARGETARCH}-${LIBRA
 FROM build-libraw AS build-imagemagick
 ARG IMAGEMAGICK_VERSION
 ARG TARGETARCH
-ENV BUILD_CACHE_DIR=/build-cache
 WORKDIR /tmp/build-imagemagick
 COPY --chmod=0755 build_imagemagick.sh .
 RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=imagemagick-${TARGETARCH}-${IMAGEMAGICK_VERSION} \
@@ -50,32 +61,17 @@ RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=imagemagick-${TARGETARCH}-${
 FROM base-cross-prep AS download-jellyfin-ffmpeg
 ARG JELLYFIN_FFMPEG_VERSION
 ARG TARGETARCH
-ENV BUILD_CACHE_DIR=/build-cache
 WORKDIR /tmp/download-ffmpeg
 COPY --chmod=0755 download_jellyfin-ffmpeg.sh .
 RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=ffmpeg-${TARGETARCH}-${JELLYFIN_FFMPEG_VERSION} \
     set -a && source /env && set +a \
     && ./download_jellyfin-ffmpeg.sh
 
-FROM build-libheif AS build-darktable
-ARG DARKTABLE_VERSION
-ARG TARGETARCH
-ENV BUILD_CACHE_DIR=/build-cache
-WORKDIR /tmp/build-darktable
-COPY --chmod=0755 build_darktable.sh .
-RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=darktable-${TARGETARCH}-${DARKTABLE_VERSION} \
-    --mount=type=secret,id=github_token \
-    if [ -f /run/secrets/github_token ]; then \
-    export GITHUB_TOKEN=$(cat /run/secrets/github_token); \
-    fi \
-    && set -a && source /env && set +a \
-    && ./build_darktable.sh
-
 FROM base-cross-prep AS final-assembly
-COPY --from=build-libraw /output/ /output/
 COPY --from=build-libheif /output/ /output/
-COPY --from=build-imagemagick /output/ /output/
 COPY --from=build-darktable /output/ /output/
+COPY --from=build-libraw /output/ /output/
+COPY --from=build-imagemagick /output/ /output/
 COPY --from=download-jellyfin-ffmpeg /output/ /output/
 COPY --chmod=0755 output.sh /
 RUN /output.sh

--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -57,19 +57,11 @@ RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=ffmpeg-${TARGETARCH}-${JELLY
     set -a && source /env && set +a \
     && ./download_jellyfin-ffmpeg.sh
 
-FROM debian:trixie-slim AS base-native-prep
-ARG TARGETPLATFORM
-SHELL ["/bin/bash", "-euo", "pipefail", "-c"]
-COPY --chmod=0755 prepare.sh /tmp/
-RUN /tmp/prepare.sh \
-    && mkdir -p /output/bin /output/lib /output/include /output/pkgconfig /output/etc /output/deb
-
-FROM base-native-prep AS build-native-darktable
+FROM build-libheif AS build-darktable
 ARG DARKTABLE_VERSION
 ARG TARGETARCH
 ENV BUILD_CACHE_DIR=/build-cache
 WORKDIR /tmp/build-darktable
-COPY --from=build-libheif /output/ /output/
 COPY --chmod=0755 build_darktable.sh .
 RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=darktable-${TARGETARCH}-${DARKTABLE_VERSION} \
     --mount=type=secret,id=github_token \
@@ -77,17 +69,13 @@ RUN --mount=type=cache,target=${BUILD_CACHE_DIR},id=darktable-${TARGETARCH}-${DA
     export GITHUB_TOKEN=$(cat /run/secrets/github_token); \
     fi \
     && set -a && source /env && set +a \
-    && cp -a /output/include/* /usr/local/include/ \
-    && cp -a /output/pkgconfig/* "${PKG_CONFIG_PATH%%:*}" \
-    && cp -a /output/lib/* /usr/local/lib/ \
-    && ldconfig \
     && ./build_darktable.sh
 
 FROM base-cross-prep AS final-assembly
 COPY --from=build-libraw /output/ /output/
 COPY --from=build-libheif /output/ /output/
 COPY --from=build-imagemagick /output/ /output/
-COPY --from=build-native-darktable /output/ /output/
+COPY --from=build-darktable /output/ /output/
 COPY --from=download-jellyfin-ffmpeg /output/ /output/
 COPY --chmod=0755 output.sh /
 RUN /output.sh

--- a/dependencies/build_darktable.sh
+++ b/dependencies/build_darktable.sh
@@ -58,14 +58,14 @@ git config submodule.src/external/lua-scripts.update none
 git submodule update --init --recursive --depth 1 --recommend-shallow --single-branch
 
 FEATURES=" \
+  --disable-camera \
+  --disable-unity \
+  --disable-colord \
   --disable-kwallet \
   --disable-libsecret \
   --disable-lua \
   --disable-mac_integration \
   --disable-map \
-  --disable-unity \
-  --disable-camera \
-  --disable-colord \
   --enable-graphicsmagick \
   --enable-imagemagick \
   --enable-jxl \

--- a/dependencies/build_darktable.sh
+++ b/dependencies/build_darktable.sh
@@ -28,40 +28,33 @@ echo "Building Darktable ${DARKTABLE_VERSION} (cache miss)..."
 echo Compiler: "${DEB_HOST_GNU_TYPE}" Arch: "${DEB_HOST_ARCH}"
 
 apt-get install -y \
-  clang \
-  git \
-  llvm \
-  python3-jsonschema \
-  libxml2-utils \
-  intltool \
-  iso-codes \
-  xsltproc \
-  zlib1g \
-  libavif-dev \
-  libcurl4-openssl-dev \
-  libexiv2-dev \
-  libgmic-dev \
-  libgraphicsmagick1-dev \
-  libgtk-3-dev \
-  libjpeg-dev \
-  libjson-glib-dev \
-  libjxl-dev \
-  liblcms2-dev \
-  liblensfun-dev \
-  libopenexr-dev \
-  libopenjp2-7-dev \
-  libpng-dev \
-  libpugixml-dev \
-  librsvg2-dev \
-  libsqlite3-dev \
-  libtiff-dev \
-  libwebp-dev
+  libavif-dev:"${DEB_HOST_ARCH}" \
+  libcurl4-openssl-dev:"${DEB_HOST_ARCH}" \
+  libexiv2-dev:"${DEB_HOST_ARCH}" \
+  libgmic-dev:"${DEB_HOST_ARCH}" \
+  libgraphicsmagick1-dev:"${DEB_HOST_ARCH}" \
+  libgtk-3-dev:"${DEB_HOST_ARCH}" \
+  libjpeg-dev:"${DEB_HOST_ARCH}" \
+  libjson-glib-dev:"${DEB_HOST_ARCH}" \
+  libjxl-dev:"${DEB_HOST_ARCH}" \
+  liblcms2-dev:"${DEB_HOST_ARCH}" \
+  liblensfun-dev:"${DEB_HOST_ARCH}" \
+  libopenexr-dev:"${DEB_HOST_ARCH}" \
+  libopenjp2-7-dev:"${DEB_HOST_ARCH}" \
+  libpng-dev:"${DEB_HOST_ARCH}" \
+  libpotrace-dev:"${DEB_HOST_ARCH}" \
+  libpugixml-dev:"${DEB_HOST_ARCH}" \
+  librsvg2-dev:"${DEB_HOST_ARCH}" \
+  libsqlite3-dev:"${DEB_HOST_ARCH}" \
+  libtiff-dev:"${DEB_HOST_ARCH}" \
+  libwebp-dev:"${DEB_HOST_ARCH}"
 
 URL="https://github.com/darktable-org/darktable.git"
 echo download Darktable repo from "$URL"
 git clone --depth 1 --single-branch --branch ${DARKTABLE_VERSION} ${URL} darktable || true
 cd darktable
 git config submodule.src/tests/integration.update none
+git config submodule.src/external/lua-scripts.update none
 git submodule update --init --recursive --depth 1 --recommend-shallow --single-branch
 
 FEATURES=" \
@@ -85,7 +78,12 @@ FEATURES=" \
   --prefix "/opt/darktable" \
   --build-type "Release" \
   --install \
-  ${FEATURES}
+  ${FEATURES} \
+  -- \
+  -DCMAKE_SYSTEM_PROCESSOR="${DEB_HOST_ARCH}" \
+  -DCMAKE_C_COMPILER="${DEB_HOST_GNU_TYPE}"-gcc \
+  -DCMAKE_CXX_COMPILER="${DEB_HOST_GNU_TYPE}"-g++ \
+  -DCMAKE_LIBRARY_ARCHITECTURE="${DEB_HOST_GNU_TYPE}"
 
 mkdir -p /output/opt
 cp -a /opt/darktable /output/opt/darktable

--- a/dependencies/build_imagemagick.sh
+++ b/dependencies/build_imagemagick.sh
@@ -54,11 +54,11 @@ cd ImageMagick-*
 
 FEATURES="--with-heic --with-jpeg --with-png --with-raw --with-tiff --with-webp"
 
+pkg-config --list-all
 ./configure \
   --enable-64bit-channel-masks \
   --enable-static --enable-shared --enable-delegate-build \
-  --without-x --without-magick-plus-plus \
-  --without-perl --disable-doc \
+  --without-x --without-magick-plus-plus --without-perl \
   --host="${DEB_HOST_GNU_TYPE}" \
   ${FEATURES}
 

--- a/dependencies/build_imagemagick.sh
+++ b/dependencies/build_imagemagick.sh
@@ -54,7 +54,6 @@ cd ImageMagick-*
 
 FEATURES="--with-heic --with-jpeg --with-png --with-raw --with-tiff --with-webp"
 
-pkg-config --list-all
 ./configure \
   --enable-64bit-channel-masks \
   --enable-static --enable-shared --enable-delegate-build \

--- a/dependencies/build_libheif.sh
+++ b/dependencies/build_libheif.sh
@@ -15,18 +15,6 @@ set -euo pipefail
 CACHE_DIR="${BUILD_CACHE_DIR:-/build-cache}/libheif-${LIBHEIF_VERSION}"
 CACHE_MARKER="${CACHE_DIR}/libheif-${LIBHEIF_VERSION}-complete"
 
-# Check if this specific version is already built and cached
-if [[ -f "$CACHE_MARKER" ]] && [[ -d "${CACHE_DIR}/output" ]]; then
-  echo "libheif ${LIBHEIF_VERSION} found in cache, reusing..."
-  mkdir -p /output
-  cp -ra "${CACHE_DIR}/output/"* /output/
-  exit 0
-fi
-
-echo "Building libheif ${LIBHEIF_VERSION} (cache miss)..."
-
-echo Compiler: "${DEB_HOST_GNU_TYPE}" Arch: "${DEB_HOST_ARCH}"
-
 apt-get install -y \
   libdav1d-dev:"${DEB_HOST_ARCH}" \
   libde265-dev:"${DEB_HOST_ARCH}" \
@@ -37,6 +25,23 @@ apt-get install -y \
   libnuma-dev:"${DEB_HOST_ARCH}" \
   zlib1g-dev:"${DEB_HOST_ARCH}"
 
+# Check if this specific version is already built and cached
+if [[ -f "$CACHE_MARKER" ]] && [[ -d "${CACHE_DIR}/output" ]]; then
+  echo "libheif ${LIBHEIF_VERSION} found in cache, reusing..."
+  mkdir -p /output /usr/local/{bin,lib,lib/pkgconfig,include}
+  cp -ra "${CACHE_DIR}/output/"* /output/
+  cp -ra /output/bin/* /usr/local/bin/
+  cp -ra /output/lib/* /usr/local/lib/
+  cp -ra /output/pkgconfig/* /usr/local/lib/pkgconfig/
+  cp -ra /output/include/* /usr/local/include/
+  ldconfig
+  exit 0
+fi
+
+echo "Building libheif ${LIBHEIF_VERSION} (cache miss)..."
+
+echo Compiler: "${DEB_HOST_GNU_TYPE}" Arch: "${DEB_HOST_ARCH}"
+
 URL="https://api.github.com/repos/strukturag/libheif/tarball/${LIBHEIF_VERSION}"
 echo download libheif from "$URL"
 curl -fsSL --retry 2 --retry-delay 5 --retry-max-time 60 -o ./libheif.tar.gz \
@@ -45,8 +50,7 @@ curl -fsSL --retry 2 --retry-delay 5 --retry-max-time 60 -o ./libheif.tar.gz \
 tar xfv ./libheif.tar.gz
 cd ./*-libheif-*
 cmake \
-  --preset=release-noplugins \
-  -DENABLE_PLUGIN_LOADING=OFF \
+  --preset=release \
   -DWITH_GDK_PIXBUF=OFF \
   -DCMAKE_SYSTEM_PROCESSOR="${DEB_HOST_ARCH}" \
   -DCMAKE_C_COMPILER="${DEB_HOST_GNU_TYPE}"-gcc \

--- a/dependencies/build_libheif.sh
+++ b/dependencies/build_libheif.sh
@@ -45,7 +45,7 @@ curl -fsSL --retry 2 --retry-delay 5 --retry-max-time 60 -o ./libheif.tar.gz \
 tar xfv ./libheif.tar.gz
 cd ./*-libheif-*
 cmake \
-  --preset=release \
+  --preset=release-noplugins \
   -DENABLE_PLUGIN_LOADING=OFF \
   -DWITH_GDK_PIXBUF=OFF \
   -DCMAKE_SYSTEM_PROCESSOR="${DEB_HOST_ARCH}" \

--- a/dependencies/build_libheif.sh
+++ b/dependencies/build_libheif.sh
@@ -32,6 +32,7 @@ apt-get install -y \
   libde265-dev:"${DEB_HOST_ARCH}" \
   libjpeg62-turbo-dev:"${DEB_HOST_ARCH}" \
   libopenh264-dev:"${DEB_HOST_ARCH}" \
+  libopenjp2-7-dev:"${DEB_HOST_ARCH}" \
   libpng-dev:"${DEB_HOST_ARCH}" \
   libnuma-dev:"${DEB_HOST_ARCH}" \
   zlib1g-dev:"${DEB_HOST_ARCH}"
@@ -45,13 +46,13 @@ tar xfv ./libheif.tar.gz
 cd ./*-libheif-*
 cmake \
   --preset=release \
+  -DENABLE_PLUGIN_LOADING=OFF \
+  -DWITH_GDK_PIXBUF=OFF \
   -DCMAKE_SYSTEM_PROCESSOR="${DEB_HOST_ARCH}" \
   -DCMAKE_C_COMPILER="${DEB_HOST_GNU_TYPE}"-gcc \
   -DCMAKE_CXX_COMPILER="${DEB_HOST_GNU_TYPE}"-g++ \
-  -DPKG_CONFIG_EXECUTABLE="${DEB_HOST_GNU_TYPE}"-pkg-config \
   -DCMAKE_LIBRARY_ARCHITECTURE="${DEB_HOST_GNU_TYPE}" \
-  -DENABLE_PLUGIN_LOADING=OFF \
-  -DWITH_GDK_PIXBUF=OFF .
+  .
 make
 make install
 cd ..

--- a/dependencies/build_libraw.sh
+++ b/dependencies/build_libraw.sh
@@ -15,22 +15,27 @@ set -euo pipefail
 CACHE_DIR="${BUILD_CACHE_DIR:-/build-cache}/LibRaw-${LIBRAW_VERSION}"
 CACHE_MARKER="${CACHE_DIR}/LibRaw-${LIBRAW_VERSION}-complete"
 
+apt-get install -y \
+  libjpeg62-turbo-dev:"${DEB_HOST_ARCH}" \
+  liblcms2-dev:"${DEB_HOST_ARCH}" \
+  zlib1g-dev:"${DEB_HOST_ARCH}"
+
 # Check if this specific version is already built and cached
 if [[ -f "$CACHE_MARKER" ]] && [[ -d "${CACHE_DIR}/output" ]]; then
   echo "LibRaw ${LIBRAW_VERSION} found in cache, reusing..."
-  mkdir -p /output
+  mkdir -p /output /usr/local/{bin,lib,lib/pkgconfig,include}
   cp -ra "${CACHE_DIR}/output/"* /output/
+  cp -ra /output/bin/* /usr/local/bin/
+  cp -ra /output/lib/* /usr/local/lib/
+  cp -ra /output/pkgconfig/* /usr/local/lib/pkgconfig/
+  cp -ra /output/include/* /usr/local/include/
+  ldconfig
   exit 0
 fi
 
 echo "Building LibRaw ${LIBRAW_VERSION} (cache miss)..."
 
 echo Compiler: "${DEB_HOST_GNU_TYPE}" Arch: "${DEB_HOST_ARCH}"
-
-apt-get install -y \
-  libjpeg62-turbo-dev:"${DEB_HOST_ARCH}" \
-  liblcms2-dev:"${DEB_HOST_ARCH}" \
-  zlib1g-dev:"${DEB_HOST_ARCH}"
 
 URL="https://api.github.com/repos/LibRaw/LibRaw/tarball/${LIBRAW_VERSION}"
 echo download libraw from "$URL"

--- a/dependencies/prepare.sh
+++ b/dependencies/prepare.sh
@@ -35,6 +35,6 @@ apt-get install -y \
   libc-dev:"${DEBIAN_ARCH}"
 
 dpkg-architecture -a "$DEBIAN_ARCH" >/env
-echo "PKG_CONFIG=/usr/bin/pkg-config" >>/env
+echo "PKG_CONFIG=$(which pkg-config)" >>/env
 echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/$(dpkg-architecture -a "$DEBIAN_ARCH" -qDEB_HOST_MULTIARCH)/pkgconfig" >>/env
 cat /env

--- a/dependencies/prepare.sh
+++ b/dependencies/prepare.sh
@@ -13,19 +13,28 @@ fi
 dpkg --add-architecture "$DEBIAN_ARCH"
 apt-get update
 apt-get install -y \
-  curl \
-  jq \
-  ca-certificates \
-  crossbuild-essential-"${DEBIAN_ARCH}" \
-  libc-dev:"${DEBIAN_ARCH}" \
-  dpkg-dev \
   autoconf \
   automake \
+  ca-certificates \
+  clang \
+  cmake \
+  curl \
+  dpkg-dev \
+  git \
+  intltool \
+  iso-codes \
+  jq \
+  llvm \
   libtool \
+  libxml2-utils \
   m4 \
   pkg-config \
-  cmake
+  python3-jsonschema \
+  xsltproc \
+  crossbuild-essential-"${DEBIAN_ARCH}" \
+  libc-dev:"${DEBIAN_ARCH}"
 
 dpkg-architecture -a "$DEBIAN_ARCH" >/env
+echo "PKG_CONFIG=/usr/bin/pkg-config" >>/env
 echo "PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:/usr/lib/$(dpkg-architecture -a "$DEBIAN_ARCH" -qDEB_HOST_MULTIARCH)/pkgconfig" >>/env
 cat /env


### PR DESCRIPTION
Export PKG_CONFIG and let `darktable` build with cross-build files. And other optimizations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced a streamlined darktable build stage and removed a redundant native build step to simplify image assembly.
  * Centralized build cache environment to reduce repetition across stages.
  * Tighter, architecture-qualified dependency installation for more predictable cross-builds.
  * Explicit toolchain/configuration selection for consistent multi-arch artifacts.
  * Expanded cache restore to repopulate runtime directories and refresh library caches for faster rebuilds.
  * Minor configure/ordering tweaks to stabilize build feature handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->