### PR TITLE
Prevent move/merge face if the target group is going to contain a duplicated pictures

### DIFF
--- a/api/graphql/resolvers/faces.go
+++ b/api/graphql/resolvers/faces.go
@@ -178,6 +178,14 @@ func (r *mutationResolver) CombineFaceGroups(ctx context.Context, destinationFac
 		sourceFaceGroups = append(sourceFaceGroups, sourceFaceGroup)
 	}
 
+	hasDuplicateMedia, err := faceGroupsWouldContainDuplicateMedia(db, destinationFaceGroupID, sourceFaceGroupIDs)
+	if err != nil {
+		return nil, err
+	}
+	if hasDuplicateMedia {
+		return nil, errors.New("cannot merge face groups because the destination would contain duplicate images")
+	}
+
 	// Perform the merge
 	updateError := db.Transaction(func(tx *gorm.DB) error {
 
@@ -246,6 +254,14 @@ func (r *mutationResolver) MoveImageFaces(ctx context.Context, imageFaceIDs []in
 
 		for _, imageFace := range userOwnedImageFaces {
 			userOwnedImageFaceIDs = append(userOwnedImageFaceIDs, imageFace.ID)
+		}
+
+		hasDuplicateMedia, err := movingImageFacesWouldCreateDuplicateMedia(tx, destFaceGroup.ID, userOwnedImageFaceIDs)
+		if err != nil {
+			return err
+		}
+		if hasDuplicateMedia {
+			return errors.New("cannot move faces because the destination would contain duplicate images")
 		}
 
 		var sourceFaceGroups []*models.FaceGroup

--- a/api/graphql/resolvers/faces.go
+++ b/api/graphql/resolvers/faces.go
@@ -178,16 +178,16 @@ func (r *mutationResolver) CombineFaceGroups(ctx context.Context, destinationFac
 		sourceFaceGroups = append(sourceFaceGroups, sourceFaceGroup)
 	}
 
-	hasDuplicateMedia, err := faceGroupsWouldContainDuplicateMedia(db, destinationFaceGroupID, sourceFaceGroupIDs)
-	if err != nil {
-		return nil, err
-	}
-	if hasDuplicateMedia {
-		return nil, errors.New("cannot merge face groups because the destination would contain duplicate images")
-	}
-
 	// Perform the merge
 	updateError := db.Transaction(func(tx *gorm.DB) error {
+
+		hasDuplicateMedia, err := faceGroupsWouldContainDuplicateMedia(tx, destinationFaceGroupID, sourceFaceGroupIDs)
+		if err != nil {
+			return err
+		}
+		if hasDuplicateMedia {
+			return errors.New("cannot merge face groups because the destination would contain duplicate images")
+		}
 
 		if err := tx.
 			Model(&models.ImageFace{}).
@@ -205,7 +205,7 @@ func (r *mutationResolver) CombineFaceGroups(ctx context.Context, destinationFac
 			Where("face_group_id = ?", destinationFaceGroup.ID).
 			Group("media_id")
 
-		err := tx.Where("face_group_id = ?", destinationFaceGroup.ID).
+		err = tx.Where("face_group_id = ?", destinationFaceGroup.ID).
 			Where("id NOT IN (?)", subQuery).
 			Delete(&models.ImageFace{}).
 			Error

--- a/api/graphql/resolvers/faces.go
+++ b/api/graphql/resolvers/faces.go
@@ -180,8 +180,8 @@ func (r *mutationResolver) CombineFaceGroups(ctx context.Context, destinationFac
 
 	// Perform the merge
 	updateError := db.Transaction(func(tx *gorm.DB) error {
-
-		hasDuplicateMedia, err := faceGroupsWouldContainDuplicateMedia(tx, destinationFaceGroupID, sourceFaceGroupIDs)
+		faceGroupIDs := append([]int{destinationFaceGroup.ID}, sourceFaceGroupIDs...)
+		hasDuplicateMedia, err := faceGroupsWouldContainDuplicateMedia(tx, faceGroupIDs...)
 		if err != nil {
 			return err
 		}

--- a/api/graphql/resolvers/faces.go
+++ b/api/graphql/resolvers/faces.go
@@ -181,7 +181,7 @@ func (r *mutationResolver) CombineFaceGroups(ctx context.Context, destinationFac
 	// Perform the merge
 	updateError := db.Transaction(func(tx *gorm.DB) error {
 		faceGroupIDs := append([]int{destinationFaceGroup.ID}, sourceFaceGroupIDs...)
-		hasDuplicateMedia, err := faceGroupsWouldContainDuplicateMedia(tx, faceGroupIDs...)
+		hasDuplicateMedia, err := hasDuplicateMediaInFaceGroupsUnion(tx, faceGroupIDs...)
 		if err != nil {
 			return err
 		}
@@ -256,7 +256,7 @@ func (r *mutationResolver) MoveImageFaces(ctx context.Context, imageFaceIDs []in
 			userOwnedImageFaceIDs = append(userOwnedImageFaceIDs, imageFace.ID)
 		}
 
-		hasDuplicateMedia, err := movingImageFacesWouldCreateDuplicateMedia(tx, destFaceGroup.ID, userOwnedImageFaceIDs)
+		hasDuplicateMedia, err := doesFaceGroupContainImages(tx, destFaceGroup.ID, userOwnedImageFaceIDs)
 		if err != nil {
 			return err
 		}

--- a/api/graphql/resolvers/faces.util.go
+++ b/api/graphql/resolvers/faces.util.go
@@ -59,25 +59,83 @@ func userOwnedFaceGroup(db *gorm.DB, user *models.User, faceGroupID int) (*model
 }
 
 func getUserOwnedImageFaces(tx *gorm.DB, user *models.User, imageFaceIDs []int) ([]*models.ImageFace, error) {
-	if err := user.FillAlbums(tx); err != nil {
-		return nil, err
-	}
-
-	userAlbumIDs := make([]int, len(user.Albums))
-	for i, album := range user.Albums {
-		userAlbumIDs[i] = album.ID
-	}
-
 	var userOwnedImageFaces []*models.ImageFace
-	if err := tx.
-		Joins("JOIN media ON media.id = image_faces.media_id").
-		Where(mediaAlbumIDInQuestion, userAlbumIDs).
+
+	if len(imageFaceIDs) == 0 {
+		return userOwnedImageFaces, nil
+	}
+
+	query := tx.Model(&models.ImageFace{})
+
+	if !user.Admin {
+		if err := user.FillAlbums(tx); err != nil {
+			return nil, err
+		}
+
+		userAlbumIDs := make([]int, len(user.Albums))
+		for i, album := range user.Albums {
+			userAlbumIDs[i] = album.ID
+		}
+
+		if len(userAlbumIDs) == 0 {
+			return userOwnedImageFaces, nil
+		}
+
+		query = query.
+			Joins("JOIN media ON media.id = image_faces.media_id").
+			Where(mediaAlbumIDInQuestion, userAlbumIDs)
+	}
+
+	if err := query.
 		Where(imageFacesIDInQuestion, imageFaceIDs).
 		Find(&userOwnedImageFaces).Error; err != nil {
 		return nil, err
 	}
 
 	return userOwnedImageFaces, nil
+}
+
+func faceGroupsWouldContainDuplicateMedia(db *gorm.DB, destinationFaceGroupID int, sourceFaceGroupIDs []int) (bool, error) {
+	faceGroupIDs := append([]int{destinationFaceGroupID}, sourceFaceGroupIDs...)
+
+	duplicateMediaQuery := db.
+		Table("image_faces").
+		Select("media_id").
+		Where("face_group_id IN ?", faceGroupIDs).
+		Group("media_id").
+		Having("COUNT(*) > 1")
+
+	var count int64
+	if err := db.
+		Table("(?) AS duplicate_media", duplicateMediaQuery).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
+}
+
+func movingImageFacesWouldCreateDuplicateMedia(db *gorm.DB, destinationFaceGroupID int, imageFaceIDs []int) (bool, error) {
+	duplicateMediaQuery := db.
+		Table("image_faces AS candidate").
+		Select("candidate.media_id").
+		Where(
+			"(candidate.face_group_id = ? AND candidate.id NOT IN ?) OR candidate.id IN ?",
+			destinationFaceGroupID,
+			imageFaceIDs,
+			imageFaceIDs,
+		).
+		Group("candidate.media_id").
+		Having("COUNT(*) > 1")
+
+	var count int64
+	if err := db.
+		Table("(?) AS duplicate_media", duplicateMediaQuery).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+
+	return count > 0, nil
 }
 
 func deleteEmptyFaceGroups(sourceFaceGroups []*models.FaceGroup, tx *gorm.DB) error {

--- a/api/graphql/resolvers/faces.util.go
+++ b/api/graphql/resolvers/faces.util.go
@@ -59,10 +59,9 @@ func userOwnedFaceGroup(db *gorm.DB, user *models.User, faceGroupID int) (*model
 }
 
 func getUserOwnedImageFaces(tx *gorm.DB, user *models.User, imageFaceIDs []int) ([]*models.ImageFace, error) {
-	var userOwnedImageFaces []*models.ImageFace
 
 	if len(imageFaceIDs) == 0 {
-		return userOwnedImageFaces, nil
+		return nil, nil
 	}
 
 	query := tx.Model(&models.ImageFace{})
@@ -78,7 +77,7 @@ func getUserOwnedImageFaces(tx *gorm.DB, user *models.User, imageFaceIDs []int) 
 		}
 
 		if len(userAlbumIDs) == 0 {
-			return userOwnedImageFaces, nil
+			return nil, nil
 		}
 
 		query = query.
@@ -86,6 +85,7 @@ func getUserOwnedImageFaces(tx *gorm.DB, user *models.User, imageFaceIDs []int) 
 			Where(mediaAlbumIDInQuestion, userAlbumIDs)
 	}
 
+	var userOwnedImageFaces []*models.ImageFace
 	if err := query.
 		Where(imageFacesIDInQuestion, imageFaceIDs).
 		Find(&userOwnedImageFaces).Error; err != nil {
@@ -95,8 +95,7 @@ func getUserOwnedImageFaces(tx *gorm.DB, user *models.User, imageFaceIDs []int) 
 	return userOwnedImageFaces, nil
 }
 
-func faceGroupsWouldContainDuplicateMedia(db *gorm.DB, destinationFaceGroupID int, sourceFaceGroupIDs []int) (bool, error) {
-	faceGroupIDs := append([]int{destinationFaceGroupID}, sourceFaceGroupIDs...)
+func faceGroupsWouldContainDuplicateMedia(db *gorm.DB, faceGroupIDs ...int) (bool, error) {
 
 	duplicateMediaQuery := db.
 		Table("image_faces").

--- a/api/graphql/resolvers/faces.util.go
+++ b/api/graphql/resolvers/faces.util.go
@@ -95,7 +95,7 @@ func getUserOwnedImageFaces(tx *gorm.DB, user *models.User, imageFaceIDs []int) 
 	return userOwnedImageFaces, nil
 }
 
-func faceGroupsWouldContainDuplicateMedia(db *gorm.DB, faceGroupIDs ...int) (bool, error) {
+func hasDuplicateMediaInFaceGroupsUnion(db *gorm.DB, faceGroupIDs ...int) (bool, error) {
 
 	duplicateMediaQuery := db.
 		Table("image_faces").
@@ -114,13 +114,13 @@ func faceGroupsWouldContainDuplicateMedia(db *gorm.DB, faceGroupIDs ...int) (boo
 	return count > 0, nil
 }
 
-func movingImageFacesWouldCreateDuplicateMedia(db *gorm.DB, destinationFaceGroupID int, imageFaceIDs []int) (bool, error) {
+func doesFaceGroupContainImages(db *gorm.DB, faceGroupID int, imageFaceIDs []int) (bool, error) {
 	duplicateMediaQuery := db.
 		Table("image_faces AS candidate").
 		Select("candidate.media_id").
 		Where(
 			"(candidate.face_group_id = ? AND candidate.id NOT IN ?) OR candidate.id IN ?",
-			destinationFaceGroupID,
+			faceGroupID,
 			imageFaceIDs,
 			imageFaceIDs,
 		).

--- a/api/graphql/resolvers/faces_test.go
+++ b/api/graphql/resolvers/faces_test.go
@@ -2,6 +2,7 @@ package resolvers
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/photoview/photoview/api/graphql/auth"
@@ -10,97 +11,364 @@ import (
 	"github.com/photoview/photoview/api/test_utils"
 )
 
-func TestCombineFaceGroups(t *testing.T) {
+func setupFaceMutationTest(t *testing.T) (*mutationResolver, context.Context, *models.User) {
+	t.Helper()
+
 	test_utils.FilesystemTest(t)
 	db := test_utils.DatabaseTest(t)
 	face_detection.InitializeFaceDetector(db)
+
 	pass := "1234"
 	user, err := models.RegisterUser(db, "test_user", &pass, true)
 	if err != nil {
 		t.Fatal("register user error:", err)
 	}
-	db.AutoMigrate(&models.ImageFace{}, &models.FaceGroup{}, &models.Media{}, &models.Album{})
-	tests := []struct {
-		name string
-		dest int
-		src  []int
-	}{
-		{
-			name: "merge multiple combinations with duplicates",
-			dest: 1,
-			src:  []int{2, 3},
-		},
-		{
-			name: "merge two combinations with duplicates",
-			dest: 1,
-			src:  []int{2},
+
+	if err := db.AutoMigrate(&models.ImageFace{}, &models.FaceGroup{}, &models.Media{}, &models.Album{}); err != nil {
+		t.Fatal("automigrate error:", err)
+	}
+
+	r := &mutationResolver{
+		Resolver: &Resolver{
+			database: db,
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
 
-			db.Exec("DELETE FROM image_faces")
-			db.Exec("DELETE FROM face_groups")
-			db.Exec("DELETE FROM media")
-			db.Exec("DELETE FROM albums")
+	return r, auth.AddUserToContext(context.Background(), user), user
+}
 
-			testAlbum := models.Album{Title: "Test Album"}
-			if err := db.Create(&testAlbum).Error; err != nil {
-				t.Fatal(err)
-			}
+func createFaceMutationFixtures(t *testing.T, r *mutationResolver) {
+	t.Helper()
 
-			testMedia := []models.Media{
-				{Model: models.Model{ID: 1}, Path: "test1", AlbumID: testAlbum.ID},
-				{Model: models.Model{ID: 2}, Path: "test2", AlbumID: testAlbum.ID},
-				{Model: models.Model{ID: 3}, Path: "test3", AlbumID: testAlbum.ID},
-				{Model: models.Model{ID: 4}, Path: "test4", AlbumID: testAlbum.ID},
-			}
-			if err := db.Create(&testMedia).Error; err != nil {
-				t.Fatal(err)
-			}
+	db := r.database
 
-			testFaceGroup := []models.FaceGroup{
-				{Model: models.Model{ID: 1}},
-				{Model: models.Model{ID: 2}},
-				{Model: models.Model{ID: 3}},
-				{Model: models.Model{ID: 4}},
-			}
-			if err := db.Create(&testFaceGroup).Error; err != nil {
-				t.Fatal(err)
-			}
-
-			testDataList := []models.ImageFace{
-				{FaceGroupID: 1, MediaID: 1},
-				{FaceGroupID: 1, MediaID: 2},
-				{FaceGroupID: 1, MediaID: 3},
-				{FaceGroupID: 2, MediaID: 3},
-				{FaceGroupID: 2, MediaID: 4},
-				{FaceGroupID: 3, MediaID: 4},
-				{FaceGroupID: 3, MediaID: 1},
-			}
-			if err := db.Create(&testDataList).Error; err != nil {
-				t.Fatal(err)
-			}
-
-			r := &mutationResolver{
-				Resolver: &Resolver{
-					database: db,
-				},
-			}
-			ctx := auth.AddUserToContext(context.Background(), user)
-
-			combineFace, err := r.CombineFaceGroups(ctx, tt.dest, tt.src)
-			if err != nil {
-				t.Fatal("test CombineFaceGroups err:", err)
-			}
-
-			m := make(map[int]struct{})
-			for _, imageface := range combineFace.ImageFaces {
-				if _, ok := m[imageface.MediaID]; ok {
-					t.Fatal("filtering failed at", imageface.MediaID)
-				}
-				m[imageface.MediaID] = struct{}{}
-			}
-		})
+	testAlbum := models.Album{Title: "Test Album", Path: "/test-album"}
+	if err := db.Create(&testAlbum).Error; err != nil {
+		t.Fatal(err)
 	}
+
+	testMedia := []models.Media{
+		{Model: models.Model{ID: 1}, Path: "test1", AlbumID: testAlbum.ID},
+		{Model: models.Model{ID: 2}, Path: "test2", AlbumID: testAlbum.ID},
+		{Model: models.Model{ID: 3}, Path: "test3", AlbumID: testAlbum.ID},
+		{Model: models.Model{ID: 4}, Path: "test4", AlbumID: testAlbum.ID},
+	}
+	if err := db.Create(&testMedia).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	testFaceGroups := []models.FaceGroup{
+		{Model: models.Model{ID: 1}},
+		{Model: models.Model{ID: 2}},
+		{Model: models.Model{ID: 3}},
+		{Model: models.Model{ID: 4}},
+	}
+	if err := db.Create(&testFaceGroups).Error; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setupNonAdminUserWithAlbum(t *testing.T, r *mutationResolver) (*models.User, context.Context) {
+	t.Helper()
+	db := r.database
+
+	pass := "5678"
+	user, err := models.RegisterUser(db, "test_nonadmin", &pass, false)
+	if err != nil {
+		t.Fatal("register non-admin user error:", err)
+	}
+
+	var album models.Album
+	if err := db.Where("path = ?", "/test-album").First(&album).Error; err != nil {
+		t.Fatal("find fixture album error:", err)
+	}
+
+	if err := db.Model(user).Association("Albums").Append(&album); err != nil {
+		t.Fatal("link non-admin user to album error:", err)
+	}
+
+	return user, auth.AddUserToContext(context.Background(), user)
+}
+
+func TestCombineFaceGroups(t *testing.T) {
+	t.Run("merges face groups when media does not overlap", func(t *testing.T) {
+		r, ctx, _ := setupFaceMutationTest(t)
+		createFaceMutationFixtures(t, r)
+
+		testDataList := []models.ImageFace{
+			{Model: models.Model{ID: 1}, FaceGroupID: 1, MediaID: 1},
+			{Model: models.Model{ID: 2}, FaceGroupID: 1, MediaID: 2},
+			{Model: models.Model{ID: 3}, FaceGroupID: 2, MediaID: 3},
+			{Model: models.Model{ID: 4}, FaceGroupID: 3, MediaID: 4},
+		}
+		if err := r.database.Create(&testDataList).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := r.CombineFaceGroups(ctx, 1, []int{2, 3})
+		if err != nil {
+			t.Fatal("CombineFaceGroups failed:", err)
+		}
+		if result == nil || result.ID != 1 {
+			t.Fatalf("expected destination face group 1, got %#v", result)
+		}
+
+		var imageFaces []*models.ImageFace
+		if err := r.database.Where("face_group_id = ?", 1).Find(&imageFaces).Error; err != nil {
+			t.Fatal("failed to query destination image faces:", err)
+		}
+
+		if len(imageFaces) != 4 {
+			t.Fatalf("expected 4 image faces after merge, got %d", len(imageFaces))
+		}
+	})
+
+	t.Run("rejects merge when destination and source contain the same media", func(t *testing.T) {
+		r, ctx, _ := setupFaceMutationTest(t)
+		createFaceMutationFixtures(t, r)
+
+		testDataList := []models.ImageFace{
+			{Model: models.Model{ID: 1}, FaceGroupID: 1, MediaID: 1},
+			{Model: models.Model{ID: 2}, FaceGroupID: 1, MediaID: 2},
+			{Model: models.Model{ID: 3}, FaceGroupID: 2, MediaID: 2},
+			{Model: models.Model{ID: 4}, FaceGroupID: 2, MediaID: 3},
+		}
+		if err := r.database.Create(&testDataList).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := r.CombineFaceGroups(ctx, 1, []int{2})
+		if err == nil {
+			t.Fatal("expected CombineFaceGroups to reject duplicate media, got nil error")
+		}
+		if result != nil {
+			t.Fatalf("expected nil result when merge is rejected, got %#v", result)
+		}
+		if !strings.Contains(err.Error(), "duplicate images") {
+			t.Fatalf("expected duplicate image validation error, got: %v", err)
+		}
+
+		var sourceCount int64
+		if err := r.database.Model(&models.ImageFace{}).Where("face_group_id = ?", 2).Count(&sourceCount).Error; err != nil {
+			t.Fatal(err)
+		}
+		if sourceCount != 2 {
+			t.Fatalf("expected source group image faces to remain unchanged, got %d", sourceCount)
+		}
+	})
+
+	t.Run("rejects merge when multiple sources contain the same media", func(t *testing.T) {
+		r, ctx, _ := setupFaceMutationTest(t)
+		createFaceMutationFixtures(t, r)
+
+		testDataList := []models.ImageFace{
+			{Model: models.Model{ID: 1}, FaceGroupID: 1, MediaID: 1},
+			{Model: models.Model{ID: 2}, FaceGroupID: 2, MediaID: 2},
+			{Model: models.Model{ID: 3}, FaceGroupID: 3, MediaID: 2},
+		}
+		if err := r.database.Create(&testDataList).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := r.CombineFaceGroups(ctx, 1, []int{2, 3})
+		if err == nil {
+			t.Fatal("expected CombineFaceGroups to reject duplicate media across sources, got nil error")
+		}
+		if result != nil {
+			t.Fatalf("expected nil result when merge is rejected, got %#v", result)
+		}
+		if !strings.Contains(err.Error(), "duplicate images") {
+			t.Fatalf("expected duplicate image validation error, got: %v", err)
+		}
+	})
+
+	t.Run("non-admin user merges owned face groups", func(t *testing.T) {
+		r, _, _ := setupFaceMutationTest(t)
+		createFaceMutationFixtures(t, r)
+		_, ctx := setupNonAdminUserWithAlbum(t, r)
+
+		testDataList := []models.ImageFace{
+			{Model: models.Model{ID: 1}, FaceGroupID: 1, MediaID: 1},
+			{Model: models.Model{ID: 2}, FaceGroupID: 1, MediaID: 2},
+			{Model: models.Model{ID: 3}, FaceGroupID: 2, MediaID: 3},
+			{Model: models.Model{ID: 4}, FaceGroupID: 3, MediaID: 4},
+		}
+		if err := r.database.Create(&testDataList).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := r.CombineFaceGroups(ctx, 1, []int{2, 3})
+		if err != nil {
+			t.Fatal("CombineFaceGroups failed for non-admin user:", err)
+		}
+		if result == nil || result.ID != 1 {
+			t.Fatalf("expected destination face group 1, got %#v", result)
+		}
+
+		var imageFaces []*models.ImageFace
+		if err := r.database.Where("face_group_id = ?", 1).Find(&imageFaces).Error; err != nil {
+			t.Fatal("failed to query destination image faces:", err)
+		}
+		if len(imageFaces) != 4 {
+			t.Fatalf("expected 4 image faces after non-admin merge, got %d", len(imageFaces))
+		}
+	})
+}
+
+func TestMoveImageFaces(t *testing.T) {
+	t.Run("moves image faces when destination does not contain selected media", func(t *testing.T) {
+		r, ctx, _ := setupFaceMutationTest(t)
+		createFaceMutationFixtures(t, r)
+
+		testDataList := []models.ImageFace{
+			{Model: models.Model{ID: 1}, FaceGroupID: 1, MediaID: 1},
+			{Model: models.Model{ID: 2}, FaceGroupID: 2, MediaID: 2},
+		}
+		if err := r.database.Create(&testDataList).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := r.MoveImageFaces(ctx, []int{1}, 2)
+		if err != nil {
+			t.Fatal("MoveImageFaces failed:", err)
+		}
+		if result == nil || result.ID != 2 {
+			t.Fatalf("expected destination face group 2, got %#v", result)
+		}
+
+		var movedFace models.ImageFace
+		if err := r.database.First(&movedFace, 1).Error; err != nil {
+			t.Fatal(err)
+		}
+		if movedFace.FaceGroupID != 2 {
+			t.Fatalf("expected image face to move to group 2, got group %d", movedFace.FaceGroupID)
+		}
+	})
+
+	t.Run("rejects move when destination already contains selected media", func(t *testing.T) {
+		r, ctx, _ := setupFaceMutationTest(t)
+		createFaceMutationFixtures(t, r)
+
+		testDataList := []models.ImageFace{
+			{Model: models.Model{ID: 1}, FaceGroupID: 1, MediaID: 1},
+			{Model: models.Model{ID: 2}, FaceGroupID: 2, MediaID: 1},
+		}
+		if err := r.database.Create(&testDataList).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := r.MoveImageFaces(ctx, []int{1}, 2)
+		if err == nil {
+			t.Fatal("expected MoveImageFaces to reject duplicate media, got nil error")
+		}
+		if result != nil {
+			t.Fatalf("expected nil result when move is rejected, got %#v", result)
+		}
+		if !strings.Contains(err.Error(), "duplicate images") {
+			t.Fatalf("expected duplicate image validation error, got: %v", err)
+		}
+
+		var originalFace models.ImageFace
+		if err := r.database.First(&originalFace, 1).Error; err != nil {
+			t.Fatal(err)
+		}
+		if originalFace.FaceGroupID != 1 {
+			t.Fatalf("expected rejected move to leave image face in group 1, got group %d", originalFace.FaceGroupID)
+		}
+	})
+
+	t.Run("rejects move when selected faces contain duplicate media", func(t *testing.T) {
+		r, ctx, _ := setupFaceMutationTest(t)
+		createFaceMutationFixtures(t, r)
+
+		testDataList := []models.ImageFace{
+			{Model: models.Model{ID: 1}, FaceGroupID: 1, MediaID: 1},
+			{Model: models.Model{ID: 2}, FaceGroupID: 3, MediaID: 1},
+			{Model: models.Model{ID: 3}, FaceGroupID: 2, MediaID: 2},
+		}
+		if err := r.database.Create(&testDataList).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := r.MoveImageFaces(ctx, []int{1, 2}, 2)
+		if err == nil {
+			t.Fatal("expected MoveImageFaces to reject duplicate selected media, got nil error")
+		}
+		if result != nil {
+			t.Fatalf("expected nil result when move is rejected, got %#v", result)
+		}
+		if !strings.Contains(err.Error(), "duplicate images") {
+			t.Fatalf("expected duplicate image validation error, got: %v", err)
+		}
+	})
+
+	t.Run("non-admin user moves owned image faces", func(t *testing.T) {
+		r, _, _ := setupFaceMutationTest(t)
+		createFaceMutationFixtures(t, r)
+		_, ctx := setupNonAdminUserWithAlbum(t, r)
+
+		testDataList := []models.ImageFace{
+			{Model: models.Model{ID: 1}, FaceGroupID: 1, MediaID: 1},
+			{Model: models.Model{ID: 2}, FaceGroupID: 2, MediaID: 2},
+		}
+		if err := r.database.Create(&testDataList).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := r.MoveImageFaces(ctx, []int{1}, 2)
+		if err != nil {
+			t.Fatal("MoveImageFaces failed for non-admin user:", err)
+		}
+		if result == nil || result.ID != 2 {
+			t.Fatalf("expected destination face group 2, got %#v", result)
+		}
+
+		var movedFace models.ImageFace
+		if err := r.database.First(&movedFace, 1).Error; err != nil {
+			t.Fatal(err)
+		}
+		if movedFace.FaceGroupID != 2 {
+			t.Fatalf("expected image face to move to group 2, got group %d", movedFace.FaceGroupID)
+		}
+	})
+}
+
+func TestGetUserOwnedImageFaces(t *testing.T) {
+	t.Run("returns empty when image face IDs list is empty", func(t *testing.T) {
+		r, _, user := setupFaceMutationTest(t)
+
+		faces, err := getUserOwnedImageFaces(r.database, user, []int{})
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if len(faces) != 0 {
+			t.Fatalf("expected 0 faces for empty input, got %d", len(faces))
+		}
+	})
+
+	t.Run("non-admin user with no album associations returns empty", func(t *testing.T) {
+		r, _, _ := setupFaceMutationTest(t)
+		createFaceMutationFixtures(t, r)
+
+		testDataList := []models.ImageFace{
+			{Model: models.Model{ID: 1}, FaceGroupID: 1, MediaID: 1},
+		}
+		if err := r.database.Create(&testDataList).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		pass := "5678"
+		userNoAlbums, err := models.RegisterUser(r.database, "test_noalbums", &pass, false)
+		if err != nil {
+			t.Fatal("register user error:", err)
+		}
+
+		faces, err := getUserOwnedImageFaces(r.database, userNoAlbums, []int{1})
+		if err != nil {
+			t.Fatal("unexpected error:", err)
+		}
+		if len(faces) != 0 {
+			t.Fatalf("expected 0 faces for user with no albums, got %d", len(faces))
+		}
+	})
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Merge now validates up front and aborts with a clear error if combining groups would introduce duplicate media into the destination.
  * Moving image faces now validates during the move and prevents operations that would create duplicate media in the destination.
  * Ownership checks now correctly handle empty selections and non-admin users.

* **Tests**
  * Expanded coverage for merges, moves, duplicate-media rejection scenarios, and non-admin/ownership cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->