### PR TITLE
Return HTTP 404 for missing file requests

### DIFF
--- a/api/routes/spa.go
+++ b/api/routes/spa.go
@@ -11,6 +11,33 @@ import (
 	"github.com/photoview/photoview/api/log"
 )
 
+// staticAssetExtensions lists file extensions considered "static asset" requests.
+// Missing files with these extensions return 404 instead of falling back to
+// index.html. This mirrors the `path_regexp staticAsset` matcher used in
+// ui/Caddyfile's `@missingStaticAsset` block, so both the Go SPA handler and
+// Caddy behave consistently.
+var staticAssetExtensions = []string{
+	".js", ".mjs", ".css",
+	".html", ".htm",
+	".md", ".map", ".json", ".webmanifest",
+	".png", ".svg", ".ico",
+	".jpg", ".jpeg", ".gif", ".webp", ".avif",
+	".woff", ".woff2", ".ttf", ".eot",
+	".txt", ".xml", ".wasm",
+}
+
+// isStaticAssetExtension reports whether ext (as returned by filepath.Ext)
+// belongs to the known set of static asset extensions.
+func isStaticAssetExtension(ext string) bool {
+	ext = strings.ToLower(ext)
+	for _, knownExt := range staticAssetExtensions {
+		if ext == knownExt {
+			return true
+		}
+	}
+	return false
+}
+
 // SpaHandler implements the http.Handler interface, so we can use it
 // to respond to HTTP requests. The path to the static directory and
 // path to the index file within that static directory are used to
@@ -97,6 +124,16 @@ func (h SpaHandler) serveOriginal(w http.ResponseWriter, r *http.Request, fullPa
 	// Check whether a file exists at the given path
 	_, err := os.Stat(fullPath)
 	if os.IsNotExist(err) {
+		// Missing requests for known static asset extensions (JS/CSS/HTML/images/
+		// fonts/etc.) should return 404 so the browser doesn't receive index.html
+		// for them. Everything else (including extension-less paths, and paths
+		// with dots that aren't recognized static extensions) is treated as an
+		// SPA route and served index.html.
+		if isStaticAssetExtension(filepath.Ext(relPath)) {
+			http.NotFound(w, r)
+			return
+		}
+
 		// File does not exist, serve index.html (SPA routing)
 		h.serveIndexHTML(w, r)
 		return

--- a/api/routes/spa_test.go
+++ b/api/routes/spa_test.go
@@ -147,6 +147,16 @@ func TestSpaHandler_ServeHTTP(t *testing.T) {
 
 		assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	})
+
+	t.Run("missing file-like request returns 404 instead of index.html", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/assets/missing-chunk.js", nil)
+		rec := httptest.NewRecorder()
+
+		handler.ServeHTTP(rec, req)
+
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+		assert.NotContains(t, rec.Body.String(), "<!DOCTYPE html>")
+	})
 }
 
 func TestSpaHandler_PrecompressedFiles(t *testing.T) {


### PR DESCRIPTION
The current implementation always falls back to the `index.html` for not existing paths in requests.
The issue is that if a request asks for a file and expects the specific MIME type in the response, getting the `index.html` instead causes the "MIME type mismatch" error in the browser's console instead of the expected "File not found" error.

This PR fixes this case.

I've declared the static list of file extensions for missing files instead of a regexp, guessing that a file was requested based on a dot in the URL or a more complex condition - such guessing will always be unreliable and can cause more bugs than solve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing JavaScript, CSS, image, and font files now return a proper 404 error instead of loading the application shell.
  * Improved handling of requests for nonexistent static assets.

* **Tests**
  * Added coverage to verify missing asset requests return 404 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->