### PR TITLE
Scanner: ensure that the album path is a folder

### DIFF
--- a/api/scanner/scanner_album.go
+++ b/api/scanner/scanner_album.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 
 	"github.com/photoview/photoview/api/graphql/models"
 	"github.com/photoview/photoview/api/log"
@@ -17,6 +18,7 @@ import (
 )
 
 func NewRootAlbum(db *gorm.DB, rootPath string, owner *models.User) (*models.Album, error) {
+	rootPath = filepath.Clean(rootPath)
 
 	if !ValidRootPath(rootPath) {
 		return nil, ErrorInvalidRootPath
@@ -75,9 +77,21 @@ func NewRootAlbum(db *gorm.DB, rootPath string, owner *models.User) (*models.Alb
 var ErrorInvalidRootPath = errors.New("invalid root path")
 
 func ValidRootPath(rootPath string) bool {
-	_, err := os.Stat(rootPath)
+	resolvedPath, err := filepath.EvalSymlinks(rootPath)
 	if err != nil {
 		log.Warn(nil, "invalid root path", "root_path", rootPath, "error", err)
+		return false
+	}
+
+	// Confirm the resolved path is actually a directory, not a file.
+	info, err := os.Stat(resolvedPath)
+	if err != nil {
+		log.Warn(nil, "invalid root path after symlink resolution",
+			"root_path", rootPath, "resolved_path", resolvedPath, "error", err)
+		return false
+	}
+	if !info.IsDir() {
+		log.Warn(nil, "root path is not a directory", "root_path", rootPath)
 		return false
 	}
 

--- a/api/scanner/scanner_album_test.go
+++ b/api/scanner/scanner_album_test.go
@@ -1,6 +1,7 @@
 package scanner_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/photoview/photoview/api/graphql/models"
@@ -71,4 +72,43 @@ func TestNewRootPath(t *testing.T) {
 		assert.EqualValues(t, 2, ownerCount)
 	})
 
+	t.Run("Insert root album pointing to a file", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp("", "photoview-rootpath-test-*")
+		if !assert.NoError(t, err) {
+			return
+		}
+		tmpFile.Close()
+		defer os.Remove(tmpFile.Name())
+
+		_, err = scanner.NewRootAlbum(db, tmpFile.Name(), &user)
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "invalid root path")
+	})
+}
+
+func TestValidRootPath(t *testing.T) {
+	t.Run("Valid directory", func(t *testing.T) {
+		assert.True(t, scanner.ValidRootPath(testDataPath))
+	})
+
+	t.Run("Non-existent path", func(t *testing.T) {
+		assert.False(t, scanner.ValidRootPath("./non_existent_path_xyz"))
+	})
+
+	t.Run("File path is rejected", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp("", "photoview-validroot-test-*")
+		if !assert.NoError(t, err) {
+			return
+		}
+		tmpFile.Close()
+		defer os.Remove(tmpFile.Name())
+
+		assert.False(t, scanner.ValidRootPath(tmpFile.Name()))
+	})
+
+	t.Run("Path with dot-slash prefix resolves correctly", func(t *testing.T) {
+		// A path like "./test_media/library/./" should resolve to the same
+		// real directory and be accepted.
+		assert.True(t, scanner.ValidRootPath(testDataPath+"/./"))
+	})
 }


### PR DESCRIPTION
This PR covers a previously uncovered case during  the media scan process:
If an album path points to a symlink that now points to a file instead of a folder, the scanner can still accept that path and go ahead with it, failing later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved album root path validation, including support for symlinked directories.
  * Normalized directory paths before validation and storage.
  * Rejected files and other non-directory paths as album roots.
  * Improved handling of invalid, missing, and unresolved paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->