### PR TITLE
Optional `rootPath` for the `user` resolver

### DIFF
--- a/api/graphql/generated.go
+++ b/api/graphql/generated.go
@@ -145,7 +145,7 @@ type ComplexityRoot struct {
 		AuthorizeUser               func(childComplexity int, username string, password string) int
 		ChangeUserPreferences       func(childComplexity int, language *string) int
 		CombineFaceGroups           func(childComplexity int, destinationFaceGroupID int, sourceFaceGroupIDs []int) int
-		CreateUser                  func(childComplexity int, username string, password *string, admin bool) int
+		CreateUser                  func(childComplexity int, username string, password *string, admin bool, rootPath *string) int
 		DeleteShareToken            func(childComplexity int, token string) int
 		DeleteUser                  func(childComplexity int, id int) int
 		DetachImageFaces            func(childComplexity int, imageFaceIDs []int) int
@@ -326,7 +326,7 @@ type MutationResolver interface {
 	AuthorizeUser(ctx context.Context, username string, password string) (*models.AuthorizeResult, error)
 	InitialSetupWizard(ctx context.Context, username string, password string, rootPath string) (*models.AuthorizeResult, error)
 	UpdateUser(ctx context.Context, id int, username *string, password *string, admin *bool) (*models.User, error)
-	CreateUser(ctx context.Context, username string, password *string, admin bool) (*models.User, error)
+	CreateUser(ctx context.Context, username string, password *string, admin bool, rootPath *string) (*models.User, error)
 	DeleteUser(ctx context.Context, id int) (*models.User, error)
 	UserAddRootPath(ctx context.Context, id int, rootPath string) (*models.Album, error)
 	UserRemoveRootAlbum(ctx context.Context, userID int, albumID int) (*models.Album, error)
@@ -829,7 +829,7 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 			return 0, false
 		}
 
-		return e.ComplexityRoot.Mutation.CreateUser(childComplexity, args["username"].(string), args["password"].(*string), args["admin"].(bool)), true
+		return e.ComplexityRoot.Mutation.CreateUser(childComplexity, args["username"].(string), args["password"].(*string), args["admin"].(bool), args["rootPath"].(*string)), true
 	case "Mutation.deleteShareToken":
 		if e.ComplexityRoot.Mutation.DeleteShareToken == nil {
 			break
@@ -2234,6 +2234,14 @@ func (ec *executionContext) field_Mutation_createUser_args(ctx context.Context, 
 		return nil, err
 	}
 	args["admin"] = arg2
+	arg3, err := graphql.ProcessArgField(ctx, rawArgs, "rootPath",
+		func(ctx context.Context, v any) (*string, error) {
+			return ec.unmarshalOString2ᚖstring(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["rootPath"] = arg3
 	return args, nil
 }
 
@@ -5761,7 +5769,7 @@ func (ec *executionContext) _Mutation_createUser(ctx context.Context, field grap
 		},
 		func(ctx context.Context) (any, error) {
 			fc := graphql.GetFieldContext(ctx)
-			return ec.Resolvers.Mutation().CreateUser(ctx, fc.Args["username"].(string), fc.Args["password"].(*string), fc.Args["admin"].(bool))
+			return ec.Resolvers.Mutation().CreateUser(ctx, fc.Args["username"].(string), fc.Args["password"].(*string), fc.Args["admin"].(bool), fc.Args["rootPath"].(*string))
 		},
 		func(ctx context.Context, next graphql.Resolver) graphql.Resolver {
 			directive0 := next

--- a/api/graphql/resolvers/user.go
+++ b/api/graphql/resolvers/user.go
@@ -145,7 +145,7 @@ func (r *mutationResolver) UpdateUser(ctx context.Context, id int, username *str
 }
 
 // CreateUser is the resolver for the createUser field.
-func (r *mutationResolver) CreateUser(ctx context.Context, username string, password *string, admin bool) (*models.User, error) {
+func (r *mutationResolver) CreateUser(ctx context.Context, username string, password *string, admin bool, rootPath *string) (*models.User, error) {
 	var user *models.User
 
 	transactionError := r.DB(ctx).Transaction(func(tx *gorm.DB) error {
@@ -153,6 +153,14 @@ func (r *mutationResolver) CreateUser(ctx context.Context, username string, pass
 		user, err = models.RegisterUser(tx, username, password, admin)
 		if err != nil {
 			return err
+		}
+
+		if rootPath != nil && *rootPath != "" {
+			cleanedPath := path.Clean(*rootPath)
+			_, err = scanner.NewRootAlbum(tx, cleanedPath, user)
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/api/graphql/resolvers/user.graphql
+++ b/api/graphql/resolvers/user.graphql
@@ -81,6 +81,7 @@ extend type Mutation {
     username: String!
     password: String
     admin: Boolean!
+    rootPath: String
   ): User! @isAdmin
   "Delete an existing user"
   deleteUser(id: ID!): User! @isAdmin


### PR DESCRIPTION
This PR adds the optional `rootPath` field to the `user` resolver.
There are no changes in UI, and these changes are mostly for compatibility with my external UI image, which has the corresponding functionality.
The main changes are in the `api/graphql/resolvers/user.go`, which is not shown on GitHub by default, so please click on the "Load diff". 
I hope that these changes are safe for this repo and won't introduce any issues, as if the UI doesn't send the new `rootPath` field, this code should be skipped and the backend should work as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional root path when creating a user.
  * When provided, the root path is cleaned and used to create the user’s initial root album.
* **Bug Fixes**
  * Ensured user registration and root album creation are completed together, preventing partially completed setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->