### PR TITLE
Fix the version commit replacement in `Dockerfile`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /app/ui
 
 COPY ui/package.json ui/package-lock.json /app/ui/
 # NPM 10.x is the latest supported version for Node.js 18.x
-RUN npm install --global npm@10 \
+RUN npm install --global npm@10 --no-audit --no-fund \
     && if [ "$NODE_ENV" = "production" ]; then \
         echo "Installing production dependencies only..."; \
         npm ci --omit=dev --no-audit --no-fund; \
@@ -122,7 +122,7 @@ RUN --mount=type=bind,from=dependencies,source=/dependencies/,target=/dependenci
     && cp -a lib/*.so* /usr/local/lib/ \
     && ldconfig \
     && DEBIAN_FRONTEND=noninteractive apt-get install \
-      -y --no-install-recommends ./deb/jellyfin-ffmpeg.deb \
+        -y --no-install-recommends ./deb/jellyfin-ffmpeg.deb \
     && ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ \
     && ln -s /usr/lib/jellyfin-ffmpeg/ffprobe /usr/local/bin/ \
     # Cleanup
@@ -137,7 +137,8 @@ COPY --from=ui /app/ui/dist /app/ui
 # This is a w/a for letting the UI build stage to be cached
 # and not rebuilt every new commit because of the build_arg value change.
 ARG COMMIT_SHA=NoCommit
-RUN find /app/ui/assets -type f -name "SettingsPage.*.js" \
+RUN find /app/ui/assets -type f \( -name "*.js" -o -name "*.mjs" \) \
+        -exec grep -qF -- '"-=<GitHub-CI-commit-sha-placeholder>=-"' {} \; \
         -exec sed -i 's/"-=<GitHub-CI-commit-sha-placeholder>=-"/"'"${COMMIT_SHA}"'"/g' {} \; \
     # Archive static files for better performance
     && find /app/ui -type f \( \


### PR DESCRIPTION
Our UI is built with Vite, which doesn't guarantee which source page goes to which JS bundle. For now, it works with the hardcoded Settings page's bundle, but after any UI code changes, the code containing the version commit placeholder can go to any different bundle because of Vite's bundle optimization rules. This has happened in my forked repo recently: https://github.com/kkovaletp/photoview/pull/1086

This fix searches for the placeholder in all JS files, so now it doesn't matter where it goes; it will be replaced anyway.

Also, I added `--no-audit --no-fund` flags to the NPM installation step in the UI stage to remove unnecessary spam from the build log.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI asset version replacement to cover all JavaScript and module files.
  * Added validation to ensure commit information is present before substitution.
  * Improved reliability of dependency setup during container builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->