### PR TITLE
Fix SQL injection in album download route

### DIFF
--- a/api/routes/downloads.go
+++ b/api/routes/downloads.go
@@ -2,11 +2,13 @@ package routes
 
 import (
 	"archive/zip"
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -17,14 +19,24 @@ import (
 
 func RegisterDownloadRoutes(db *gorm.DB, router *mux.Router) {
 	router.HandleFunc("/album/{album_id}/{media_purpose}", func(w http.ResponseWriter, r *http.Request) {
-		albumID := mux.Vars(r)["album_id"]
+		albumID, err := strconv.Atoi(mux.Vars(r)["album_id"])
+		if err != nil || albumID <= 0 {
+			http.Error(w, "invalid album id", http.StatusBadRequest)
+			return
+		}
+
 		mediaPurpose := mux.Vars(r)["media_purpose"]
 		mediaPurposeList := strings.SplitN(mediaPurpose, ",", 10)
 
 		var album models.Album
-		if err := db.Find(&album, albumID).Error; err != nil {
+		if err := db.First(&album, "id = ?", albumID).Error; errors.Is(err, gorm.ErrRecordNotFound) {
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte("404"))
+			return
+		} else if err != nil {
+			log.Printf("ERROR: failed to find album for download: %v\n", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(internalServerError))
 			return
 		}
 

--- a/api/routes/downloads_test.go
+++ b/api/routes/downloads_test.go
@@ -1,7 +1,7 @@
 package routes
 
 import (
-	"errors"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -69,11 +69,26 @@ func TestDownloadRouteReturnsNotFoundForMissingAlbum(t *testing.T) {
 }
 
 func TestDownloadRouteReturnsInternalServerErrorForDatabaseFailure(t *testing.T) {
-	db := test_utils.DatabaseTest(t).Session(&gorm.Session{})
-	forcedError := errors.New("forced album lookup failure")
-	assert.ErrorIs(t, db.AddError(forcedError), forcedError)
+	db := test_utils.DatabaseTest(t)
+	ctx := context.Background()
 
-	rec := requestAlbumDownload(db, "1")
+	// Force First to return a real query error without closing the shared test pool.
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatalf("get database pool: %v", err)
+	}
+	connection, err := sqlDB.Conn(ctx)
+	if err != nil {
+		t.Fatalf("get dedicated database connection: %v", err)
+	}
+	if err := connection.Close(); err != nil {
+		t.Fatalf("close dedicated database connection: %v", err)
+	}
+
+	failingDB := db.WithContext(ctx)
+	failingDB.Statement.ConnPool = connection
+
+	rec := requestAlbumDownload(failingDB, "1")
 
 	assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	assert.Equal(t, internalServerError, rec.Body.String())

--- a/api/routes/downloads_test.go
+++ b/api/routes/downloads_test.go
@@ -1,21 +1,31 @@
 package routes
 
 import (
-	"fmt"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/gorilla/mux"
 	"github.com/photoview/photoview/api/graphql/models"
 	"github.com/photoview/photoview/api/test_utils"
 	"github.com/stretchr/testify/assert"
+	"gorm.io/gorm"
 )
 
-func TestDownloadRouteRejectsInvalidAlbumIDsBeforeDatabaseLookup(t *testing.T) {
+func requestAlbumDownload(db *gorm.DB, albumID string) *httptest.ResponseRecorder {
 	router := mux.NewRouter()
-	RegisterDownloadRoutes(nil, router)
+	RegisterDownloadRoutes(db, router)
 
+	req := httptest.NewRequest(http.MethodGet, "/album/"+albumID+"/original", nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	return rec
+}
+
+func TestDownloadRouteRejectsInvalidAlbumIDsBeforeDatabaseLookup(t *testing.T) {
 	tests := []struct {
 		name    string
 		albumID string
@@ -30,10 +40,7 @@ func TestDownloadRouteRejectsInvalidAlbumIDsBeforeDatabaseLookup(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, "/album/"+test.albumID+"/original", nil)
-			rec := httptest.NewRecorder()
-
-			router.ServeHTTP(rec, req)
+			rec := requestAlbumDownload(nil, test.albumID)
 
 			assert.Equal(t, http.StatusBadRequest, rec.Code)
 			assert.Equal(t, "invalid album id\n", rec.Body.String())
@@ -46,13 +53,28 @@ func TestDownloadRouteAcceptsNumericAlbumID(t *testing.T) {
 	album := models.Album{Title: "download-test", Path: t.TempDir()}
 	assert.NoError(t, db.Create(&album).Error)
 
-	router := mux.NewRouter()
-	RegisterDownloadRoutes(db, router)
-
-	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/album/%d/original", album.ID), nil)
-	rec := httptest.NewRecorder()
-	router.ServeHTTP(rec, req)
+	rec := requestAlbumDownload(db, strconv.Itoa(album.ID))
 
 	assert.Equal(t, http.StatusForbidden, rec.Code)
 	assert.Contains(t, rec.Body.String(), "unauthorized")
+}
+
+func TestDownloadRouteReturnsNotFoundForMissingAlbum(t *testing.T) {
+	db := test_utils.DatabaseTest(t)
+
+	rec := requestAlbumDownload(db, "1")
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Equal(t, "404", rec.Body.String())
+}
+
+func TestDownloadRouteReturnsInternalServerErrorForDatabaseFailure(t *testing.T) {
+	db := test_utils.DatabaseTest(t).Session(&gorm.Session{})
+	forcedError := errors.New("forced album lookup failure")
+	assert.ErrorIs(t, db.AddError(forcedError), forcedError)
+
+	rec := requestAlbumDownload(db, "1")
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Equal(t, internalServerError, rec.Body.String())
 }

--- a/api/routes/downloads_test.go
+++ b/api/routes/downloads_test.go
@@ -1,0 +1,58 @@
+package routes
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/photoview/photoview/api/graphql/models"
+	"github.com/photoview/photoview/api/test_utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDownloadRouteRejectsInvalidAlbumIDsBeforeDatabaseLookup(t *testing.T) {
+	router := mux.NewRouter()
+	RegisterDownloadRoutes(nil, router)
+
+	tests := []struct {
+		name    string
+		albumID string
+	}{
+		{name: "text", albumID: "not-a-number"},
+		{name: "SQL condition", albumID: "id%3D1%20OR%201%3D1"},
+		{name: "time-based SQL condition", albumID: "id%3D1%20AND%20SLEEP%281%29"},
+		{name: "zero", albumID: "0"},
+		{name: "negative", albumID: "-1"},
+		{name: "integer overflow", albumID: "999999999999999999999999999999999999"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/album/"+test.albumID+"/original", nil)
+			rec := httptest.NewRecorder()
+
+			router.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			assert.Equal(t, "invalid album id\n", rec.Body.String())
+		})
+	}
+}
+
+func TestDownloadRouteAcceptsNumericAlbumID(t *testing.T) {
+	db := test_utils.DatabaseTest(t)
+	album := models.Album{Title: "download-test", Path: t.TempDir()}
+	assert.NoError(t, db.Create(&album).Error)
+
+	router := mux.NewRouter()
+	RegisterDownloadRoutes(db, router)
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/album/%d/original", album.ID), nil)
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+	assert.Contains(t, rec.Body.String(), "unauthorized")
+}


### PR DESCRIPTION
## Summary

- Parse the `album_id` route parameter as a positive integer before database access.
- Use an explicit bound primary-key lookup instead of passing an untrusted string to `Find`.
- Distinguish missing albums from database failures.
- Add regression coverage for malformed and SQL-shaped album IDs.

## Why

`mux.Vars` returns `album_id` as a string. Passing a nonnumeric string directly as the second argument to GORM `Find` causes GORM to interpret it as a SQL condition. This lookup occurs before album authorization, making the route vulnerable to unauthenticated SQL injection (CWE-89).

The route now rejects invalid identifiers before touching the database and performs the lookup using an explicitly parameterized primary-key condition.

## Tests

- `go test -tags no_face_detection ./routes -count=1 -database`
- `go vet -tags no_face_detection ./routes`

Both pass in the project's API dependency environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Download requests now validate `album ID` as a positive number and return a clear **400** for invalid values.
  * Downloads for missing albums now return **404** (not an internal error).
  * Album retrieval errors now return an appropriate **500**.
  * Authorization behavior for valid album IDs remains enforced.
* **Tests**
  * Expanded download-route test coverage for invalid IDs, missing albums, unauthorized cases, and database error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->