### PR TITLE
Prevent ExifTool argument injection from multiline paths

### DIFF
--- a/api/scanner/externaltools/exiftool/exiftool.go
+++ b/api/scanner/externaltools/exiftool/exiftool.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strings"
 	"sync"
 )
 
@@ -29,6 +30,8 @@ type Exiftool struct {
 
 const marker = "{ready}\n"
 const bufferSize = 10240
+
+var errArgumentContainsLineBreak = errors.New("exiftool arguments cannot contain line breaks")
 
 // New returns a new instance of Exiftool.
 func New() (*Exiftool, error) {
@@ -120,6 +123,14 @@ func (e *Exiftool) Close() (err error) {
 }
 
 func (e *Exiftool) rawSendCommand(args ...string) error {
+	// The -@ protocol treats each line as a separate argument. Validate the
+	// complete command first so rejection cannot leave partial input buffered.
+	for _, arg := range args {
+		if strings.ContainsAny(arg, "\r\n") {
+			return errArgumentContainsLineBreak
+		}
+	}
+
 	e.stdout.Reset()
 	e.stderr.Reset()
 

--- a/api/scanner/externaltools/exiftool/exiftool_test.go
+++ b/api/scanner/externaltools/exiftool/exiftool_test.go
@@ -1,6 +1,9 @@
 package exiftool
 
 import (
+	"bufio"
+	"bytes"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -32,6 +35,57 @@ func TestExiftool(t *testing.T) {
 
 	if err := instance.Close(); err != nil {
 		t.Errorf("close instance error: %v", err)
+	}
+}
+
+func TestExiftoolRejectsLineBreaksBeforeWriting(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+	}{
+		{name: "line feed", arg: "photo.jpg\n-if\n1"},
+		{name: "carriage return", arg: "photo.jpg\r-if\r1"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var command bytes.Buffer
+			instance := &Exiftool{stdinBuf: bufio.NewWriter(&command)}
+
+			err := instance.rawSendCommand("-n", tc.arg)
+			if err != errArgumentContainsLineBreak {
+				t.Fatalf("rawSendCommand() error = %v, want %v", err, errArgumentContainsLineBreak)
+			}
+
+			if err := instance.stdinBuf.Flush(); err != nil {
+				t.Fatalf("flush buffered command: %v", err)
+			}
+			if command.Len() != 0 {
+				t.Fatalf("rawSendCommand() wrote %q before rejecting the argument", command.String())
+			}
+		})
+	}
+}
+
+func TestExiftoolRemainsUsableAfterRejectingArgumentInjection(t *testing.T) {
+	instance, err := New()
+	if err != nil {
+		t.Fatalf("new error: %v", err)
+	}
+	defer instance.Close()
+
+	var value struct{ MIMEType }
+	malformedFile := "./test_data/no_exif.jpg\n-if\n1"
+	if err := instance.QueryJSONTagsByNumber(malformedFile, &value); !errors.Is(err, errArgumentContainsLineBreak) {
+		t.Fatalf("QueryJSONTagsByNumber(%q) error = %v, want %v", malformedFile, err, errArgumentContainsLineBreak)
+	}
+
+	file := "./test_data/no_exif.jpg"
+	if err := instance.QueryJSONTagsByNumber(file, &value); err != nil {
+		t.Fatalf("QueryJSONTagsByNumber(%q) after rejection: %v", file, err)
+	}
+	if got, want := value.MIMEType.MIMEType, "image/jpeg"; got == nil || *got != want {
+		t.Fatalf("MIMEType(%q) = %v, want %q", file, got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reject carriage returns and line feeds in arguments before writing to ExifTool's persistent argument stream.
- Validate the complete command before changing reader state or buffering bytes, preventing rejected input from desynchronizing the next request.
- Add regression tests for CR/LF injection, zero-byte writes on rejection, and successful process reuse afterward.

## Security impact

Photoview runs ExifTool with `-stay_open True -@ -` and writes each argument as a line on standard input. Unix filenames may contain line breaks, so writing a scanner-controlled path verbatim can turn one path into multiple ExifTool arguments. An attacker who can place a scanner-visible file with such a name can inject ExifTool options and reach command execution under the Photoview process account.

The validation is applied in `rawSendCommand`, covering metadata queries, MIME detection, embedded-preview extraction, output paths, and future call sites using this transport.

## Tests

- `go test ./scanner/externaltools/exiftool -count=1`
- `go test -tags no_face_detection ./scanner/... -count=1`
- `go test -tags no_face_detection ./... -p 1 -count=1`
- `go vet -tags no_face_detection ./scanner/...`

All commands pass in the project's dependency image with ExifTool 13.25.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security when processing ExifTool commands by rejecting arguments containing line breaks.
  * Prevented potentially injected command content from being sent.
  * Ensured ExifTool remains usable after rejecting invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->