### PR TITLE
fix: properly interpolate username in Change Password dialog

### DIFF
--- a/ui/src/Pages/SettingsPage/Users/UserChangePassword.tsx
+++ b/ui/src/Pages/SettingsPage/Users/UserChangePassword.tsx
@@ -39,7 +39,7 @@ const ChangePasswordModal = ({
       onClose={onClose}
       title={t('settings.users.password_reset.title', 'Change password')}
       description={
-        <Trans t={t} i18nKey="settings.users.password_reset.description">
+        <Trans t={t} i18nKey="settings.users.password_reset.description" values={{ username: user.username }}>
           Change password for <b>{user.username}</b>
         </Trans>
       }


### PR DESCRIPTION
Closes #761

## Problem

The Change Password dialog shows `{{username}}` literally instead of the actual username. For example, the dialog prompts "Change password for {{username}}" instead of "Change password for John".

## Root Cause

The `Trans` component from `react-i18next` was missing the `values` prop. The translation file correctly uses `{{username}}` as an interpolation variable, but the component never passed the `username` value to the translator.

## Solution

Added `values={{ username: user.username }}` to the `Trans` component so that `{{username}}` in the translation is properly interpolated with the actual user's username.

## Test URLs

- Settings page > Users > Click "Change password" button next to any user
- The dialog should now show "Change password for \<username\>" with the correct username

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the password-change dialog so the current username is displayed correctly in its description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->