### PR TITLE
feat: add option to disable swipe navigation in gallery view

### DIFF
--- a/ui/src/Pages/SettingsPage/UserPreferences.tsx
+++ b/ui/src/Pages/SettingsPage/UserPreferences.tsx
@@ -16,8 +16,9 @@ import {
   changeUserPreferencesVariables,
 } from './__generated__/changeUserPreferences'
 import { myUserPreferences } from './__generated__/myUserPreferences'
+import { changeTheme, getTheme, getSwipeNavigationDisabled, setSwipeNavigationDisabled } from '../../theme'
 import { TranslationFn } from '../../localization'
-import { changeTheme, getTheme } from '../../theme'
+import Checkbox from '../../primitives/form/Checkbox'
 
 const languagePreferences = [
   { key: 1, label: 'English', value: LanguageTranslation.English },
@@ -98,6 +99,7 @@ const UserPreferencesWrapper = styled.div`
 const UserPreferences = () => {
   const { t } = useTranslation()
   const [theme, setTheme] = useState(getTheme())
+  const [swipeDisabled, setSwipeDisabled] = useState(getSwipeNavigationDisabled())
 
   const changeStateTheme = (value: string) => {
     changeTheme(value)
@@ -173,6 +175,26 @@ const UserPreferences = () => {
         items={themePreferences(t)}
         setSelected={changeStateTheme}
         selected={theme}
+      />
+      <label htmlFor="user_pref_disable_swipe_field">
+        <InputLabelTitle>
+          {t('settings.user_preferences.swipe_navigation.title', 'Gallery swipe navigation')}
+        </InputLabelTitle>
+        <InputLabelDescription>
+          {t(
+            'settings.user_preferences.swipe_navigation.description',
+            'Disable horizontal swipe gestures in gallery view to prevent accidental navigation while pinch-to-zooming on touch devices'
+          )}
+        </InputLabelDescription>
+      </label>
+      <Checkbox
+        id="user_pref_disable_swipe_field"
+        label={t('settings.user_preferences.swipe_navigation.checkbox_label', 'Disable swipe navigation in gallery')}
+        checked={swipeDisabled}
+        onChange={(e) => {
+          setSwipeNavigationDisabled(e.currentTarget.checked)
+          setSwipeDisabled(e.currentTarget.checked)
+        }}
       />
     </UserPreferencesWrapper>
   )

--- a/ui/src/components/photoGallery/presentView/PresentNavigationOverlay.tsx
+++ b/ui/src/components/photoGallery/presentView/PresentNavigationOverlay.tsx
@@ -8,6 +8,7 @@ import { useSwipeable } from 'react-swipeable'
 import ExitIcon from './icons/Exit'
 import NextIcon from './icons/Next'
 import PrevIcon from './icons/Previous'
+import { getSwipeNavigationDisabled } from '../../../theme'
 
 const StyledOverlayContainer = styled.div`
   width: 100%;
@@ -95,12 +96,14 @@ const PresentNavigationOverlay = ({
     }
   }, [])
 
-  const handlers = useSwipeable({
-    onSwipedLeft: () => dispatchMedia({ type: 'nextImage' }),
-    onSwipedRight: () => dispatchMedia({ type: 'previousImage' }),
-    preventScrollOnSwipe: false,
-    trackMouse: false,
-  })
+  const handlers = getSwipeNavigationDisabled()
+    ? {}
+    : useSwipeable({
+        onSwipedLeft: () => dispatchMedia({ type: 'nextImage' }),
+        onSwipedRight: () => dispatchMedia({ type: 'previousImage' }),
+        preventScrollOnSwipe: true,
+        trackMouse: false,
+      })
 
   return (
     <StyledOverlayContainer

--- a/ui/src/theme.ts
+++ b/ui/src/theme.ts
@@ -35,3 +35,17 @@ export const getTheme = () => {
 
 export const isDarkMode = () =>
   document.documentElement.classList.contains('dark')
+
+export const SWIPE_NAVIGATION_KEY = 'swipeNavigationDisabled'
+
+export const getSwipeNavigationDisabled = (): boolean => {
+  return localStorage.getItem(SWIPE_NAVIGATION_KEY) === 'true'
+}
+
+export const setSwipeNavigationDisabled = (disabled: boolean) => {
+  if (disabled) {
+    localStorage.setItem(SWIPE_NAVIGATION_KEY, 'true')
+  } else {
+    localStorage.removeItem(SWIPE_NAVIGATION_KEY)
+  }
+}


### PR DESCRIPTION
## Summary
Adds a user preference toggle in Settings to disable horizontal swipe gestures in the gallery (presentation) view on touch devices. This prevents accidental navigation while pinch-to-zooming on tablets and touch devices.

## Changes
- **`ui/src/theme.ts`**: Added `getSwipeNavigationDisabled()` and `setSwipeNavigationDisabled()` utility functions (localStorage-based, similar to theme preference)
- **`ui/src/Pages/SettingsPage/UserPreferences.tsx`**: Added a checkbox "Disable swipe navigation in gallery" in the User Preferences section
- **`ui/src/components/photoGallery/presentView/PresentNavigationOverlay.tsx`**: Conditionally apply `useSwipeable` handlers based on the user preference; changed `preventScrollOnSwipe` to `true` to prevent browser scroll interference

## Testing
- All existing tests pass (100 passed, 1 skipped, 25 test files)
- The feature is client-side only (localStorage), no backend changes needed

## How it works
When the checkbox is checked:
- `useSwipeable` handlers are not applied to the gallery overlay
- Arrow buttons and keyboard navigation (ArrowLeft/ArrowRight) continue to work normally
- Pinch-to-zoom is unaffected

Closes #1380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a setting to enable or disable swipe navigation in the photo gallery.
  - The preference is saved and remembered across sessions.
  - When enabled, swiping moves between photos while preventing unintended page scrolling.

- **Bug Fixes**
  - Improved swipe behavior in the photo viewer by preventing background scrolling during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->