### PR TITLE
fix: reload sharing options when sidebar media changes

### DIFF
--- a/ui/src/components/sidebar/Sharing.tsx
+++ b/ui/src/components/sidebar/Sharing.tsx
@@ -460,7 +460,7 @@ export const SidebarPhotoShare = ({ id }: SidebarSharePhotoProps) => {
         },
       })
     }
-  }, [])
+  }, [id])
 
   const loading = queryLoading || mutationLoading
 


### PR DESCRIPTION
## Description

When the sidebar is pinned and the user clicks on a different media item without closing the sidebar, the "Sharing options" section shows stale data from the previously viewed media. The access link is not refreshed.

## Root Cause

The `SidebarPhotoShare` component uses `useLazyQuery` with a `useEffect` that has an empty dependency array `[]`. When the `id` prop changes (new media selected), the effect does not re-run, so the shares query is never re-executed.

## Fix

Added `id` to the `useEffect` dependency array so the shares query is re-fetched whenever the media selection changes.

## Test Plan

1. Open Photoview on the Timeline page
2. Click on the (i) button of a media item without a share link
3. Without closing the sidebar, click on (i) of a different media item that has a share link
4. **Before fix**: The share link from the first media is still shown
5. **After fix**: The share link is correctly loaded for the new media

Closes #925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Photo-sharing details now refresh correctly when switching between photos in the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->