### PR TITLE
feat: add 'new album' indicator badge for recently created albums

### DIFF
--- a/api/graphql/generated.go
+++ b/api/graphql/generated.go
@@ -49,6 +49,7 @@ type DirectiveRoot struct {
 
 type ComplexityRoot struct {
 	Album struct {
+		CreatedAt   func(childComplexity int) int
 		FilePath    func(childComplexity int) int
 		ID          func(childComplexity int) int
 		Media       func(childComplexity int, order *models.Ordering, paginate *models.Pagination, onlyFavorites *bool) int
@@ -453,6 +454,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Album.Title(childComplexity), true
+	case "Album.createdAt":
+		if e.ComplexityRoot.Album.CreatedAt == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Album.CreatedAt(childComplexity), true
 
 	case "AuthorizeResult.status":
 		if e.ComplexityRoot.AuthorizeResult.Status == nil {
@@ -1669,6 +1676,8 @@ func (ec *executionContext) childFields_Album(ctx context.Context, field graphql
 		return ec.fieldContext_Album_path(ctx, field)
 	case "shares":
 		return ec.fieldContext_Album_shares(ctx, field)
+	case "createdAt":
+		return ec.fieldContext_Album_createdAt(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type Album", field.Name)
 }
@@ -3292,6 +3301,29 @@ func (ec *executionContext) fieldContext_Album_shares(_ context.Context, field g
 		},
 	}
 	return fc, nil
+}
+
+func (ec *executionContext) _Album_createdAt(ctx context.Context, field graphql.CollectedField, obj *models.Album) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Album_createdAt(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.CreatedAt, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v time.Time) graphql.Marshaler {
+			return ec.marshalNTime2timeᚐTime(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Album_createdAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Album", field, false, false, errors.New("field of type Time does not have child fields"))
 }
 
 func (ec *executionContext) _AuthorizeResult_success(ctx context.Context, field graphql.CollectedField, obj *models.AuthorizeResult) (ret graphql.Marshaler) {

--- a/api/graphql/resolvers/album.graphql
+++ b/api/graphql/resolvers/album.graphql
@@ -1,6 +1,8 @@
 type Album {
   id: ID!
   title: String!
+  "When the album was created"
+  createdAt: Time!
 
   "The media inside this album"
   media(

--- a/ui/src/Pages/AlbumPage/__generated__/albumQuery.ts
+++ b/ui/src/Pages/AlbumPage/__generated__/albumQuery.ts
@@ -30,6 +30,7 @@ export interface albumQuery_album_subAlbums {
   __typename: "Album";
   id: string;
   title: string;
+  createdAt: string;
   /**
    * An image in this album used for previewing this album
    */

--- a/ui/src/Pages/AllAlbumsPage/AlbumsPage.tsx
+++ b/ui/src/Pages/AllAlbumsPage/AlbumsPage.tsx
@@ -17,6 +17,7 @@ const getAlbumsQuery = gql`
     ) {
       id
       title
+      createdAt
       thumbnail {
         id
         thumbnail {

--- a/ui/src/Pages/AllAlbumsPage/__generated__/getMyAlbums.ts
+++ b/ui/src/Pages/AllAlbumsPage/__generated__/getMyAlbums.ts
@@ -30,6 +30,7 @@ export interface getMyAlbums_myAlbums {
   __typename: "Album";
   id: string;
   title: string;
+  createdAt: string;
   /**
    * An image in this album used for previewing this album
    */

--- a/ui/src/Pages/SharePage/AlbumSharePage.tsx
+++ b/ui/src/Pages/SharePage/AlbumSharePage.tsx
@@ -26,6 +26,7 @@ export const SHARE_ALBUM_QUERY = gql`
       subAlbums(order: { order_by: "title" }) {
         id
         title
+        createdAt
         thumbnail {
           id
           thumbnail {

--- a/ui/src/Pages/SharePage/__generated__/shareAlbumQuery.ts
+++ b/ui/src/Pages/SharePage/__generated__/shareAlbumQuery.ts
@@ -30,6 +30,7 @@ export interface shareAlbumQuery_album_subAlbums {
   __typename: "Album";
   id: string;
   title: string;
+  createdAt: string;
   /**
    * An image in this album used for previewing this album
    */

--- a/ui/src/components/albumGallery/AlbumBox.tsx
+++ b/ui/src/components/albumGallery/AlbumBox.tsx
@@ -3,11 +3,23 @@ import { Link } from 'react-router-dom'
 import { ProtectedImage } from '../photoGallery/ProtectedMedia'
 import { albumQuery_album_subAlbums } from '../../Pages/AlbumPage/__generated__/albumQuery'
 
-interface AlbumBoxImageProps {
-  src?: string
+const NEW_ALBUM_DAYS = 14
+
+function isNewAlbum(createdAt?: string): boolean {
+  if (!createdAt) return false
+  const created = new Date(createdAt)
+  const now = new Date()
+  const diffMs = now.getTime() - created.getTime()
+  const diffDays = diffMs / (1000 * 60 * 60 * 24)
+  return diffDays <= NEW_ALBUM_DAYS
 }
 
-const AlbumBoxImage = ({ src, ...props }: AlbumBoxImageProps) => {
+interface AlbumBoxImageProps {
+  src?: string
+  isNew?: boolean
+}
+
+const AlbumBoxImage = ({ src, isNew, ...props }: AlbumBoxImageProps) => {
   const [loaded, setLoaded] = useState(false)
 
   let image = null
@@ -33,6 +45,13 @@ const AlbumBoxImage = ({ src, ...props }: AlbumBoxImageProps) => {
     <div className="xs:w-[220px] xs:h-[220px] relative rounded-lg">
       {image}
       {placeholder}
+      {isNew && (
+        <div className="absolute top-2 right-2 z-10">
+          <span className="bg-green-500 text-white text-xs font-bold px-2 py-0.5 rounded shadow-md">
+            NEW
+          </span>
+        </div>
+      )}
     </div>
   )
 }
@@ -53,7 +72,7 @@ export const AlbumBox = ({ album, customLink, ...props }: AlbumBoxProps) => {
         className={wrapperClasses}
         {...props}
       >
-        <AlbumBoxImage src={album.thumbnail?.thumbnail?.url} />
+        <AlbumBoxImage src={album.thumbnail?.thumbnail?.url} isNew={isNewAlbum(album.createdAt)} />
         <p className="whitespace-nowrap overflow-hidden overflow-ellipsis">
           {album.title}
         </p>

--- a/ui/src/components/albumGallery/AlbumGallery.tsx
+++ b/ui/src/components/albumGallery/AlbumGallery.tsx
@@ -19,6 +19,7 @@ export const ALBUM_GALLERY_FRAGMENT = gql`
   fragment AlbumGalleryFields on Album {
     id
     title
+    createdAt
     subAlbums(order: { order_by: "title", order_direction: $orderDirection }) {
       id
       title

--- a/ui/src/components/albumGallery/__generated__/AlbumGalleryFields.ts
+++ b/ui/src/components/albumGallery/__generated__/AlbumGalleryFields.ts
@@ -30,6 +30,7 @@ export interface AlbumGalleryFields_subAlbums {
   __typename: "Album";
   id: string;
   title: string;
+  createdAt: string;
   /**
    * An image in this album used for previewing this album
    */


### PR DESCRIPTION
Adds a green **NEW** badge to album covers for albums created within the last 14 days.

**Backend changes:**
- Added `createdAt: Time!` field to the Album GraphQL schema
- Implemented the field resolver (auto-maps to the existing `Model.CreatedAt` database column)

**Frontend changes:**
- Added `createdAt` to the `AlbumGalleryFields` GraphQL fragment
- Added `createdAt` to all subAlbum queries (album page, all albums page, share page)
- `AlbumBox` component now calculates if an album is "new" (created within 14 days) and displays a green NEW badge in the top-right corner of the album cover

Closes #987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added album creation dates to album data.
  * Albums created within the past 14 days now display a “NEW” badge.
  * Creation dates are available for albums in galleries and shared albums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->