### PR TITLE
fix: queue valid albums when discovery reports errors

### DIFF
--- a/api/scanner/scanner_queue/queue.go
+++ b/api/scanner/scanner_queue/queue.go
@@ -2,6 +2,7 @@ package scanner_queue
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"log"
 	"sync"
@@ -223,9 +224,6 @@ func AddAllToQueue() error {
 func AddUserToQueue(user *models.User) error {
 	albumCache := scanner_cache.MakeAlbumCache()
 	albums, album_errors := scanner.FindAlbumsForUser(global_scanner_queue.db, user, albumCache)
-	for _, err := range album_errors {
-		return errors.Wrapf(err, "find albums for user (user_id: %d)", user.ID)
-	}
 
 	global_scanner_queue.mutex.Lock()
 	for _, album := range albums {
@@ -235,7 +233,12 @@ func AddUserToQueue(user *models.User) error {
 	}
 	global_scanner_queue.mutex.Unlock()
 
-	return nil
+	wrappedErrors := make([]error, len(album_errors))
+	for i, err := range album_errors {
+		wrappedErrors[i] = errors.Wrapf(err, "find albums for user (user_id: %d)", user.ID)
+	}
+
+	return stderrors.Join(wrappedErrors...)
 }
 
 // Queue should be locked prior to calling this function

--- a/api/scanner/scanner_test.go
+++ b/api/scanner/scanner_test.go
@@ -2,6 +2,7 @@ package scanner_test
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -9,7 +10,9 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/photoview/photoview/api/graphql/models"
+	"github.com/photoview/photoview/api/graphql/notification"
 	"github.com/photoview/photoview/api/scanner/face_detection"
+	"github.com/photoview/photoview/api/scanner/scanner_queue"
 	"github.com/photoview/photoview/api/test_utils"
 	scanner_utils "github.com/photoview/photoview/api/test_utils/scanner"
 )
@@ -247,6 +250,126 @@ func TestFullScan(t *testing.T) {
 			}
 		}
 	})
+}
+
+func TestScanQueuesValidAlbumsWhenDiscoveryFails(t *testing.T) {
+	test_utils.FilesystemTest(t)
+	db := test_utils.DatabaseTest(t)
+
+	pass := "1234"
+	user, err := models.RegisterUser(db, "partial_scan_user", &pass, true)
+	if err != nil {
+		t.Fatal("register user error:", err)
+	}
+
+	validRoot := t.TempDir()
+	mediaContents, err := os.ReadFile("test_media/real_media/jpeg.jpg")
+	if err != nil {
+		t.Fatal("read test media error:", err)
+	}
+	if err := os.WriteFile(filepath.Join(validRoot, "jpeg.jpg"), mediaContents, 0o600); err != nil {
+		t.Fatal("write test media error:", err)
+	}
+
+	rootAlbums := []models.Album{
+		{Title: "valid root", Path: validRoot},
+		{Title: "missing root 1", Path: filepath.Join(t.TempDir(), "missing")},
+		{Title: "missing root 2", Path: filepath.Join(t.TempDir(), "missing")},
+	}
+	if err := db.Create(&rootAlbums).Error; err != nil {
+		t.Fatal("create root albums error:", err)
+	}
+	if err := db.Model(user).Association("Albums").Append(&rootAlbums); err != nil {
+		t.Fatal("bind root albums error:", err)
+	}
+
+	if err := scanner_queue.InitializeScannerQueue(db); err != nil {
+		t.Fatal("initialize scanner queue error:", err)
+	}
+	discoveryErr := scanner_queue.AddUserToQueue(user)
+	scanner_queue.CloseScannerQueue()
+
+	if discoveryErr == nil {
+		t.Fatal("expected album discovery error")
+	}
+	for _, album := range rootAlbums[1:] {
+		if !strings.Contains(discoveryErr.Error(), album.Path) {
+			t.Errorf("discovery error %q does not contain missing root %q", discoveryErr, album.Path)
+		}
+	}
+
+	var media []models.Media
+	if err := db.Find(&media).Error; err != nil {
+		t.Fatal("get scanned media error:", err)
+	}
+	if got, want := len(media), 1; got != want {
+		t.Fatalf("scanned media count = %d, want %d", got, want)
+	}
+	if got, want := media[0].Title, "jpeg.jpg"; got != want {
+		t.Errorf("scanned media title = %q, want %q", got, want)
+	}
+}
+
+func TestScanWithOnlyDiscoveryErrorsQueuesNoAlbums(t *testing.T) {
+	db := test_utils.DatabaseTest(t)
+
+	pass := "1234"
+	user, err := models.RegisterUser(db, "failed_scan_user", &pass, true)
+	if err != nil {
+		t.Fatal("register user error:", err)
+	}
+
+	missingRoot := models.Album{
+		Title: "missing root",
+		Path:  filepath.Join(t.TempDir(), "missing"),
+	}
+	if err := db.Create(&missingRoot).Error; err != nil {
+		t.Fatal("create root album error:", err)
+	}
+	if err := db.Model(user).Association("Albums").Append(&missingRoot); err != nil {
+		t.Fatal("bind root album error:", err)
+	}
+
+	notifications := make(chan *models.Notification, 1)
+	listenerID := notification.RegisterListener(user, notifications)
+	listenerRegistered := true
+	defer func() {
+		if listenerRegistered {
+			if err := notification.DeregisterListener(listenerID); err != nil {
+				t.Errorf("deregister notification listener error: %v", err)
+			}
+		}
+	}()
+
+	if err := scanner_queue.InitializeScannerQueue(db); err != nil {
+		t.Fatal("initialize scanner queue error:", err)
+	}
+	discoveryErr := scanner_queue.AddUserToQueue(user)
+
+	select {
+	case got := <-notifications:
+		t.Errorf("unexpected scanner notification after failed discovery: %+v", got)
+	default:
+	}
+	if err := notification.DeregisterListener(listenerID); err != nil {
+		t.Errorf("deregister notification listener error: %v", err)
+	}
+	listenerRegistered = false
+	scanner_queue.CloseScannerQueue()
+
+	if discoveryErr == nil {
+		t.Fatal("expected album discovery error")
+	}
+	if !strings.Contains(discoveryErr.Error(), missingRoot.Path) {
+		t.Errorf("discovery error %q does not contain missing root %q", discoveryErr, missingRoot.Path)
+	}
+	var mediaCount int64
+	if err := db.Model(&models.Media{}).Count(&mediaCount).Error; err != nil {
+		t.Fatal("count scanned media error:", err)
+	}
+	if mediaCount != 0 {
+		t.Errorf("scanned media count = %d, want 0", mediaCount)
+	}
 }
 
 func equalNameWithoutSuffix(a, b string) bool {


### PR DESCRIPTION
Large or complex libraries can complete album discovery without ever starting media indexing, leaving album rows in the database while the scanner becomes idle. The thread confirms that small libraries scan successfully and that rescanning the already-created albums through another user can index their media. In the current queue wiring, `FindAlbumsForUser` may return usable albums together with traversal errors, but `AddUserToQueue` returns on the first error before adding any of those albums to the scanner queue. This all-or-nothing handoff explains how partial discovery can persist the folder hierarchy while suppressing every subsequent media job.

A user whose album discovery has no errors queues all discovered albums and indexes their media as before.

## Summary by CodeRabbit

Change `AddUserToQueue` in `api/scanner/scanner_queue/queue.go` so every successfully discovered album is enqueued even when `FindAlbumsForUser` also reports one or more directory-level errors. Preserve the error signal for the GraphQL and periodic-scan callers by returning the joined discovery errors only after the valid jobs have been scheduled; do not hide unreadable paths or treat failed albums as successful. Keep the existing album-ID deduplication and queue notification path intact so partial discovery cannot create duplicate media jobs.

Closes #1190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved album scanning when some album locations cannot be discovered.
  * Valid albums are now scanned even if other locations fail.
  * Discovery errors are reported together instead of stopping at the first failure.
  * Scan status now indicates when some albums could not be queued.
  * Prevented notifications from being sent when no albums can be scanned.
  * Ensured scanning completes cleanly when all configured album locations are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->