### PR TITLE
Update the specific fields of the token record instead of overwriting the record completely

### DIFF
--- a/api/graphql/models/actions/share_token_actions.go
+++ b/api/graphql/models/actions/share_token_actions.go
@@ -134,7 +134,7 @@ func ProtectShareToken(db *gorm.DB, user *models.User, tokenValue string, passwo
 
 	token.Password = hashedPassword
 
-	if err := db.Save(&token).Error; err != nil {
+	if err := db.Model(token).Update("password", token.Password).Error; err != nil {
 		return nil, errors.Wrap(err, "failed to update password for share token")
 	}
 
@@ -149,7 +149,7 @@ func SetExpireShareToken(db *gorm.DB, user *models.User, tokenValue string, expi
 
 	token.Expire = expire
 
-	if err := db.Save(&token).Error; err != nil {
+	if err := db.Model(token).Update("expire", token.Expire).Error; err != nil {
 		return nil, errors.Wrap(err, "failed to update the expiration date for share token")
 	}
 
@@ -164,7 +164,7 @@ func SetShareTokenLabel(db *gorm.DB, user *models.User, tokenValue string, label
 
 	token.Label = utils.SanitizeShareLabel(label)
 
-	if err := db.Save(&token).Error; err != nil {
+	if err := db.Model(token).Update("label", token.Label).Error; err != nil {
 		return nil, errors.Wrap(err, "failed to update label for share token")
 	}
 


### PR DESCRIPTION
I've got this recommendation from the bot during the upstream changes merge, so I'm backporting it here.
In theory, this should be safer because it doesn't overwrite other fields that other threads can modify concurrently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Share-token protection, expiration, and label updates now correctly report when no token was changed, preventing unsuccessful updates from being treated as successful.
  * Database errors during share-token updates are now surfaced accurately instead of being hidden, improving reliability and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->